### PR TITLE
Fix to enable reads to failover to preferred/secondary regions

### DIFF
--- a/sdk/cosmos/azure-cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 #### Bugs Fixed
 
+* Enabled read failover to preferred locations in the case of single-write/multi-read region enabled account. See [Bug: Cosmos DB Client gets stuck in timeout retry loop](https://github.com/Azure/azure-sdk-for-java/issues/31260#issue-1396454421)
+
 #### Other Changes
 
 ### 4.37.0 (2022-09-30)

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/ClientRetryPolicy.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/ClientRetryPolicy.java
@@ -100,7 +100,7 @@ public class ClientRetryPolicy extends DocumentClientRetryPolicy {
                 Exceptions.isSubStatusCode(clientException, HttpConstants.SubStatusCodes.FORBIDDEN_WRITEFORBIDDEN))
         {
             logger.warn("Endpoint not writable. Will refresh cache and retry ", e);
-            return this.shouldRetryOnEndpointFailureAsync(false, true);
+            return this.shouldRetryOnEndpointFailureAsync(false, true, false);
         }
 
         // Regional endpoint is not available yet for reads (e.g. add/ online of region is in progress)
@@ -110,7 +110,7 @@ public class ClientRetryPolicy extends DocumentClientRetryPolicy {
                 this.isReadRequest)
         {
             logger.warn("Endpoint not available for reads. Will refresh cache and retry. ", e);
-            return this.shouldRetryOnEndpointFailureAsync(true, false);
+            return this.shouldRetryOnEndpointFailureAsync(true, false, false);
         }
 
         // Received Connection error (HttpRequestException), initiate the endpoint rediscovery
@@ -118,9 +118,9 @@ public class ClientRetryPolicy extends DocumentClientRetryPolicy {
             if (clientException != null && Exceptions.isSubStatusCode(clientException, HttpConstants.SubStatusCodes.GATEWAY_ENDPOINT_UNAVAILABLE)) {
                 if (this.isReadRequest || WebExceptionUtility.isWebExceptionRetriable(e)) {
                     logger.warn("Gateway endpoint not reachable. Will refresh cache and retry. ", e);
-                    return this.shouldRetryOnEndpointFailureAsync(this.isReadRequest, false);
+                    return this.shouldRetryOnEndpointFailureAsync(this.isReadRequest, false, isReadRequest);
                 } else {
-                    return this.shouldNotRetryOnEndpointFailureAsync(this.isReadRequest, false);
+                    return this.shouldNotRetryOnEndpointFailureAsync(this.isReadRequest, false, false);
                 }
             } else if (clientException != null &&
                 WebExceptionUtility.isReadTimeoutException(clientException) &&
@@ -228,13 +228,13 @@ public class ClientRetryPolicy extends DocumentClientRetryPolicy {
         return this.rxCollectionCache.refreshAsync(null, this.request).then(Mono.just(ShouldRetryResult.retryAfter(Duration.ZERO)));
     }
 
-    private Mono<ShouldRetryResult> shouldRetryOnEndpointFailureAsync(boolean isReadRequest , boolean forceRefresh) {
+    private Mono<ShouldRetryResult> shouldRetryOnEndpointFailureAsync(boolean isReadRequest , boolean forceRefresh, boolean usePreferredLocations) {
         if (!this.enableEndpointDiscovery || this.failoverRetryCount > MaxRetryCount) {
             logger.warn("ShouldRetryOnEndpointFailureAsync() Not retrying. Retry count = {}", this.failoverRetryCount);
             return Mono.just(ShouldRetryResult.noRetry());
         }
 
-        Mono<Void> refreshLocationCompletable = this.refreshLocation(isReadRequest, forceRefresh);
+        Mono<Void> refreshLocationCompletable = this.refreshLocation(isReadRequest, forceRefresh, usePreferredLocations);
 
         // Some requests may be in progress when the endpoint manager and client are closed.
         // In that case, the request won't succeed since the http client is closed.
@@ -253,16 +253,16 @@ public class ClientRetryPolicy extends DocumentClientRetryPolicy {
         return refreshLocationCompletable.then(Mono.just(ShouldRetryResult.retryAfter(retryDelay)));
     }
 
-    private Mono<ShouldRetryResult> shouldNotRetryOnEndpointFailureAsync(boolean isReadRequest , boolean forceRefresh) {
+    private Mono<ShouldRetryResult> shouldNotRetryOnEndpointFailureAsync(boolean isReadRequest , boolean forceRefresh, boolean usePreferredLocations) {
         if (!this.enableEndpointDiscovery || this.failoverRetryCount > MaxRetryCount) {
             logger.warn("ShouldRetryOnEndpointFailureAsync() Not retrying. Retry count = {}", this.failoverRetryCount);
             return Mono.just(ShouldRetryResult.noRetry());
         }
-        Mono<Void> refreshLocationCompletable = this.refreshLocation(isReadRequest, forceRefresh);
+        Mono<Void> refreshLocationCompletable = this.refreshLocation(isReadRequest, forceRefresh, usePreferredLocations);
         return refreshLocationCompletable.then(Mono.just(ShouldRetryResult.noRetry()));
     }
 
-    private Mono<Void> refreshLocation(boolean isReadRequest, boolean forceRefresh) {
+    private Mono<Void> refreshLocation(boolean isReadRequest, boolean forceRefresh, boolean usePreferredLocations) {
         this.failoverRetryCount++;
 
         // Mark the current read endpoint as unavailable
@@ -274,7 +274,7 @@ public class ClientRetryPolicy extends DocumentClientRetryPolicy {
             this.globalEndpointManager.markEndpointUnavailableForWrite(this.locationEndpoint);
         }
 
-        this.retryContext = new RetryContext(this.failoverRetryCount, false);
+        this.retryContext = new RetryContext(this.failoverRetryCount, usePreferredLocations);
         return this.globalEndpointManager.refreshLocationAsync(null, forceRefresh);
     }
 
@@ -337,6 +337,10 @@ public class ClientRetryPolicy extends DocumentClientRetryPolicy {
     @Override
     public com.azure.cosmos.implementation.RetryContext getRetryContext() {
         return BridgeInternal.getRetryContext(this.getCosmosDiagnostics());
+    }
+
+    public boolean canUsePreferredLocations() {
+        return this.retryContext != null && this.retryContext.retryRequestOnPreferredLocations;
     }
 
     CosmosDiagnostics getCosmosDiagnostics() {

--- a/sdk/cosmos/azure-cosmos/src/test/java/com/azure/cosmos/implementation/ClientRetryPolicyTest.java
+++ b/sdk/cosmos/azure-cosmos/src/test/java/com/azure/cosmos/implementation/ClientRetryPolicyTest.java
@@ -9,6 +9,7 @@ import com.azure.cosmos.ThrottlingRetryOptions;
 import io.netty.handler.timeout.ReadTimeoutException;
 import io.reactivex.subscribers.TestSubscriber;
 import org.mockito.Mockito;
+import org.testng.Assert;
 import org.testng.annotations.Test;
 import reactor.core.publisher.Mono;
 
@@ -52,6 +53,8 @@ public class ClientRetryPolicyTest {
 
             Mockito.verify(endpointManager, Mockito.times(i + 1)).markEndpointUnavailableForRead(Mockito.any());
             Mockito.verify(endpointManager, Mockito.times(0)).markEndpointUnavailableForWrite(Mockito.any());
+
+            Assert.assertTrue(clientRetryPolicy.canUsePreferredLocations());
         }
     }
 
@@ -85,11 +88,15 @@ public class ClientRetryPolicyTest {
                     .shouldRetry(true)
                     .backOfTime(Duration.ofMillis(0))
                     .build());
+
+                Assert.assertTrue(clientRetryPolicy.canUsePreferredLocations());
             } else {
                 validateSuccess(shouldRetry, ShouldRetryValidator.builder()
                     .nullException()
                     .shouldRetry(false)
                     .build());
+
+                Assert.assertFalse(clientRetryPolicy.canUsePreferredLocations());
             }
 
             Mockito.verify(endpointManager, Mockito.times(0)).markEndpointUnavailableForRead(Mockito.any());
@@ -176,11 +183,15 @@ public class ClientRetryPolicyTest {
                     .shouldRetry(true)
                     .backOfTime(Duration.ofMillis(0))
                     .build());
+
+                Assert.assertTrue(clientRetryPolicy.canUsePreferredLocations());
             } else {
                 validateSuccess(shouldRetry, ShouldRetryValidator.builder()
                     .nullException()
                     .shouldRetry(false)
                     .build());
+
+                Assert.assertFalse(clientRetryPolicy.canUsePreferredLocations());
             }
 
             Mockito.verify(endpointManager, Mockito.times(0)).markEndpointUnavailableForRead(Mockito.any());
@@ -214,6 +225,8 @@ public class ClientRetryPolicyTest {
 
             Mockito.verify(endpointManager, Mockito.times(0)).markEndpointUnavailableForRead(Mockito.any());
             Mockito.verify(endpointManager, Mockito.times(i + 1)).markEndpointUnavailableForWrite(Mockito.any());
+
+            Assert.assertFalse(clientRetryPolicy.canUsePreferredLocations());
         }
     }
 
@@ -246,6 +259,8 @@ public class ClientRetryPolicyTest {
 
             Mockito.verify(endpointManager, Mockito.times(0)).markEndpointUnavailableForRead(Mockito.any());
             Mockito.verify(endpointManager, Mockito.times(0)).markEndpointUnavailableForWrite(Mockito.any());
+
+            Assert.assertFalse(clientRetryPolicy.canUsePreferredLocations());
         }
     }
 
@@ -276,6 +291,8 @@ public class ClientRetryPolicyTest {
 
             Mockito.verify(endpointManager, Mockito.times(0)).markEndpointUnavailableForRead(Mockito.any());
             Mockito.verify(endpointManager, Mockito.times(i + 1)).markEndpointUnavailableForWrite(Mockito.any());
+
+            Assert.assertFalse(clientRetryPolicy.canUsePreferredLocations());
         }
     }
 
@@ -308,6 +325,8 @@ public class ClientRetryPolicyTest {
 
             Mockito.verify(endpointManager, Mockito.times(0)).markEndpointUnavailableForRead(Mockito.any());
             Mockito.verify(endpointManager, Mockito.times(0)).markEndpointUnavailableForWrite(Mockito.any());
+
+            Assert.assertFalse(clientRetryPolicy.canUsePreferredLocations());
         }
     }
 


### PR DESCRIPTION
# Description

See [Bug: Cosmos DB Client gets stuck in timeout retry loop](https://github.com/Azure/azure-sdk-for-java/issues/31260#issue-1396454421)

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md).**

## [General Guidelines and Best Practices](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md#developer-guide)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md#building-and-unit-testing)
- [ ] Pull request includes test coverage for the included changes.
