### PR TITLE
[Spark]SupportSystemPropertyForFeedRangeCacheRefreshInterval

### DIFF
--- a/sdk/cosmos/azure-cosmos-spark_3_2-12/src/main/scala/com/azure/cosmos/spark/CosmosConstants.scala
+++ b/sdk/cosmos/azure-cosmos-spark_3_2-12/src/main/scala/com/azure/cosmos/spark/CosmosConstants.scala
@@ -19,7 +19,6 @@ private[cosmos] object CosmosConstants {
   val maxRetryIntervalForTransientFailuresInMs = 5000
   val maxRetryCountForTransientFailures = 100
   val defaultDirectRequestTimeoutInSeconds = 10L
-  val feedRangesCacheIntervalInMinutes = 1L
   val defaultIoThreadCountFactorPerCore = 4
   val smallestPossibleReactorQueueSizeLargerThanOne: Int = math.min(8, Queues.XS_BUFFER_SIZE)
   val readOperationEndToEndTimeoutInSeconds = 65
@@ -88,5 +87,15 @@ private[cosmos] object CosmosConstants {
       Option(System.getProperty(MetricsHistoryDecayFactorPropertyName))
        .orElse(sys.env.get(MetricsHistoryDecayFactorEnvName))
        .getOrElse(DefaultMetricsHistoryDecayFactor).toDouble
+  }
+
+  object ContainerFeedRangesCacheConfigs {
+    private val FeedRangeRefreshIntervalPropertyName = "spark.cosmos.container.feedRange.refresh.interval"
+    private val FeedRangeRefreshIntervalEnvName = "SPARK.COSMOS.CONTAINER.FEEDRANGE.REFRESH.INTERVAL"
+    private val DefaultFeedRangeRefreshIntervalInMins = "5"
+    val feedRangeRefreshInterval: Long =
+      Option(System.getProperty(FeedRangeRefreshIntervalPropertyName))
+       .orElse(sys.env.get(FeedRangeRefreshIntervalEnvName))
+       .getOrElse(DefaultFeedRangeRefreshIntervalInMins).toLong
   }
 }


### PR DESCRIPTION
- change default refresh interval to every 5mins
- added system property support for tuning the feed range refresh interval

> 