### PR TITLE
Add enhanced logging for pk range cache and suppress page size for pkrange read feed

### DIFF
--- a/sdk/cosmos/azure-cosmos-spark_3_2-12/src/test/scala/com/azure/cosmos/spark/SparkE2EChangeFeedSplitITest.scala
+++ b/sdk/cosmos/azure-cosmos-spark_3_2-12/src/test/scala/com/azure/cosmos/spark/SparkE2EChangeFeedSplitITest.scala
@@ -103,7 +103,7 @@ class SparkE2EChangeFeedSplitITest
    response.getStatusCode shouldEqual 200
 
    // Disable FeedRange cache refresh to enforce that the cached feed ranges won't be aware of splits
-   ContainerFeedRangesCache.overrideFeedRangeRefreshInterval(Int.MaxValue)
+//   ContainerFeedRangesCache.overrideFeedRangeRefreshInterval(Int.MaxValue)
 
    try {
     val initialPartitionCount = df1.rdd.getNumPartitions
@@ -131,7 +131,7 @@ class SparkE2EChangeFeedSplitITest
     rowsArray2 should have size 50 - initialCount
    } finally {
     // Resetting FeedRange cache refresh to avoid unintended side-effects for other tests
-    ContainerFeedRangesCache.resetFeedRangeRefreshInterval()
+//    ContainerFeedRangesCache.resetFeedRangeRefreshInterval()
    }
   }
  }

--- a/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/rx/changefeed/pkversion/IncrementalChangeFeedProcessorTest.java
+++ b/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/rx/changefeed/pkversion/IncrementalChangeFeedProcessorTest.java
@@ -38,6 +38,15 @@ import com.azure.cosmos.models.SqlQuerySpec;
 import com.azure.cosmos.models.ThroughputProperties;
 import com.azure.cosmos.models.ThroughputResponse;
 import com.azure.cosmos.rx.TestSuiteBase;
+import com.azure.cosmos.test.faultinjection.CosmosFaultInjectionHelper;
+import com.azure.cosmos.test.faultinjection.FaultInjectionCondition;
+import com.azure.cosmos.test.faultinjection.FaultInjectionConditionBuilder;
+import com.azure.cosmos.test.faultinjection.FaultInjectionOperationType;
+import com.azure.cosmos.test.faultinjection.FaultInjectionResultBuilders;
+import com.azure.cosmos.test.faultinjection.FaultInjectionRule;
+import com.azure.cosmos.test.faultinjection.FaultInjectionRuleBuilder;
+import com.azure.cosmos.test.faultinjection.FaultInjectionServerErrorResult;
+import com.azure.cosmos.test.faultinjection.FaultInjectionServerErrorType;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -182,6 +191,90 @@ public class IncrementalChangeFeedProcessorTest extends TestSuiteBase {
             Thread.sleep(500);
         }
      }
+
+    @Test(groups = { "long-emulator" }/*, timeOut = 4 * TIMEOUT*/)
+    public void readFeedDocumentsStartFromBeginningWithPkRangeThrottles() throws InterruptedException {
+        CosmosAsyncContainer createdFeedCollection
+            = client.getDatabase("TestDb").getContainer("TestFeedContainer");
+        CosmosAsyncContainer createdLeaseCollection
+            = client.getDatabase("TestDb").getContainer("TestLeaseContainer");
+
+        try {
+            List<InternalObjectNode> createdDocuments = new ArrayList<>();
+            Map<String, JsonNode> receivedDocuments = new ConcurrentHashMap<>();
+//            setupReadFeedDocuments(createdDocuments, createdFeedCollection, FEED_COUNT);
+
+            changeFeedProcessor = new ChangeFeedProcessorBuilder()
+                .hostName(hostName)
+                .handleChanges(changeFeedProcessorHandler(receivedDocuments))
+                .feedContainer(createdFeedCollection)
+                .leaseContainer(createdLeaseCollection)
+                .options(new ChangeFeedProcessorOptions()
+                    .setLeaseRenewInterval(Duration.ofSeconds(20))
+                    .setLeaseAcquireInterval(Duration.ofSeconds(10))
+                    .setLeaseExpirationInterval(Duration.ofSeconds(30))
+                    .setFeedPollDelay(Duration.ofSeconds(2))
+                    .setLeasePrefix("TEST")
+                    .setMaxItemCount(10)
+                    .setStartFromBeginning(true)
+                    .setMaxScaleCount(0) // unlimited
+                )
+                .buildChangeFeedProcessor();
+
+            FeedRange fullRange = FeedRange.forFullRange();
+
+            FaultInjectionServerErrorResult pkRangeThrottledError = FaultInjectionResultBuilders
+                .getResultBuilder(FaultInjectionServerErrorType.TOO_MANY_REQUEST)
+                .suppressServiceRequests(false)
+                .build();
+
+            FaultInjectionCondition condition = new FaultInjectionConditionBuilder()
+                .operationType(FaultInjectionOperationType.METADATA_REQUEST_PARTITION_KEY_RANGES)
+                .build();
+
+            String pkRangeThrottledId = String.format("pkrange-throttled-error-%s", UUID.randomUUID());
+
+            FaultInjectionRuleBuilder ruleBuilder = new FaultInjectionRuleBuilder(pkRangeThrottledId)
+                .condition(condition)
+                .result(pkRangeThrottledError);
+
+            FaultInjectionRule pkRangeThrottledFIErrorRule = ruleBuilder.build();
+
+            CosmosFaultInjectionHelper.configureFaultInjectionRules(createdFeedCollection, Arrays.asList(pkRangeThrottledFIErrorRule)).block();
+
+            startChangeFeedProcessor(changeFeedProcessor);
+
+            // Wait for the feed processor to receive and process the documents.
+            Thread.sleep(20000 * CHANGE_FEED_PROCESSOR_TIMEOUT);
+
+            assertThat(changeFeedProcessor.isStarted()).as("Change Feed Processor instance is running").isTrue();
+
+            safeStopChangeFeedProcessor(changeFeedProcessor);
+            for (InternalObjectNode item : createdDocuments) {
+                assertThat(receivedDocuments.containsKey(item.getId())).as("Document with getId: " + item.getId()).isTrue();
+            }
+
+            // Wait for the feed processor to shutdown.
+            Thread.sleep(CHANGE_FEED_PROCESSOR_TIMEOUT);
+
+            // restart the change feed processor and verify it can start successfully
+            startChangeFeedProcessor(changeFeedProcessor);
+
+            // Wait for the feed processor to start
+            Thread.sleep(2 * CHANGE_FEED_PROCESSOR_TIMEOUT);
+
+            assertThat(changeFeedProcessor.isStarted()).as("Change Feed Processor instance is running").isTrue();
+
+            safeStopChangeFeedProcessor(changeFeedProcessor);
+            // Wait for the feed processor to shutdown.
+            Thread.sleep(CHANGE_FEED_PROCESSOR_TIMEOUT);
+        } finally {
+//            safeDeleteCollection(createdFeedCollection);
+//            safeDeleteCollection(createdLeaseCollection);
+
+            // Allow some time for the collections to be deleted before exiting.            Thread.sleep(500);
+        }
+    }
 
     @Test(groups = { "long-emulator" }, timeOut = 50 * CHANGE_FEED_PROCESSOR_TIMEOUT)
     public void readFeedDocumentsStartFromCustomDate() throws InterruptedException {

--- a/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/rx/changefeed/pkversion/IncrementalChangeFeedProcessorTest.java
+++ b/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/rx/changefeed/pkversion/IncrementalChangeFeedProcessorTest.java
@@ -192,7 +192,7 @@ public class IncrementalChangeFeedProcessorTest extends TestSuiteBase {
         }
      }
 
-    @Test(groups = { "long-emulator" }/*, timeOut = 4 * TIMEOUT*/)
+    @Test(groups = { "long-emulator" }, enabled = false, timeOut = 12 * TIMEOUT)
     public void readFeedDocumentsStartFromBeginningWithPkRangeThrottles() throws InterruptedException {
         CosmosAsyncContainer createdFeedCollection
             = client.getDatabase("TestDb").getContainer("TestFeedContainer");
@@ -202,7 +202,6 @@ public class IncrementalChangeFeedProcessorTest extends TestSuiteBase {
         try {
             List<InternalObjectNode> createdDocuments = new ArrayList<>();
             Map<String, JsonNode> receivedDocuments = new ConcurrentHashMap<>();
-//            setupReadFeedDocuments(createdDocuments, createdFeedCollection, FEED_COUNT);
 
             changeFeedProcessor = new ChangeFeedProcessorBuilder()
                 .hostName(hostName)

--- a/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/rx/changefeed/pkversion/IncrementalChangeFeedProcessorTest.java
+++ b/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/rx/changefeed/pkversion/IncrementalChangeFeedProcessorTest.java
@@ -192,7 +192,7 @@ public class IncrementalChangeFeedProcessorTest extends TestSuiteBase {
         }
      }
 
-    @Test(groups = { "long-emulator" }, enabled = true, timeOut = 12 * TIMEOUT)
+    @Test(groups = { "long-emulator" }, enabled = false, timeOut = 12 * TIMEOUT)
     public void readFeedDocumentsStartFromBeginningWithPkRangeThrottles() throws InterruptedException {
         CosmosAsyncContainer createdFeedCollection
             = client.getDatabase("TestDb").getContainer("TestFeedContainer");

--- a/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/rx/changefeed/pkversion/IncrementalChangeFeedProcessorTest.java
+++ b/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/rx/changefeed/pkversion/IncrementalChangeFeedProcessorTest.java
@@ -192,7 +192,7 @@ public class IncrementalChangeFeedProcessorTest extends TestSuiteBase {
         }
      }
 
-    @Test(groups = { "long-emulator" }, enabled = false, timeOut = 12 * TIMEOUT)
+    @Test(groups = { "long-emulator" }, enabled = true, timeOut = 12 * TIMEOUT)
     public void readFeedDocumentsStartFromBeginningWithPkRangeThrottles() throws InterruptedException {
         CosmosAsyncContainer createdFeedCollection
             = client.getDatabase("TestDb").getContainer("TestFeedContainer");

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/CosmosException.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/CosmosException.java
@@ -369,7 +369,7 @@ public class CosmosException extends AzureException {
             if (StringUtils.isNotEmpty(header)) {
                 try {
                     retryIntervalInMilliseconds = Math.min(Long.parseLong(header), MAX_RETRY_AFTER_IN_MS);
-                    logger.warn("Resolved retryAfterInMilliseconds : [{}] from RetryAfterInMilliseconds header: [{}].", retryIntervalInMilliseconds, header);
+                    logger.warn("Resolved retryAfterInMilliseconds : [{}] from RetryAfterInMilliseconds header : [{}] and MAX_RETRY_AFTER_IN_MS : [{}].", retryIntervalInMilliseconds, header, MAX_RETRY_AFTER_IN_MS);
                 } catch (NumberFormatException e) {
                     // If the value cannot be parsed as long, return 0.
                     logger.warn("SubStatusCode [{}] cannot be parsed as Integer.", header);

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/CosmosException.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/CosmosException.java
@@ -19,6 +19,8 @@ import com.azure.cosmos.implementation.directconnectivity.rntbd.RntbdEndpointSta
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
 import java.util.HashMap;
@@ -47,6 +49,8 @@ import static com.azure.cosmos.CosmosDiagnostics.USER_AGENT_KEY;
  * service, an IllegalStateException is thrown instead of CosmosException.
  */
 public class CosmosException extends AzureException {
+
+    private final static Logger logger = LoggerFactory.getLogger(CosmosException.class);
     private static final long MAX_RETRY_AFTER_IN_MS = BatchExecUtils.MAX_RETRY_AFTER_IN_MS;
     private static final long serialVersionUID = 1L;
 
@@ -365,8 +369,10 @@ public class CosmosException extends AzureException {
             if (StringUtils.isNotEmpty(header)) {
                 try {
                     retryIntervalInMilliseconds = Math.min(Long.parseLong(header), MAX_RETRY_AFTER_IN_MS);
+                    logger.warn("Resolved retryAfterInMilliseconds : [{}] from RetryAfterInMilliseconds header: [{}].", retryIntervalInMilliseconds, header);
                 } catch (NumberFormatException e) {
                     // If the value cannot be parsed as long, return 0.
+                    logger.warn("SubStatusCode [{}] cannot be parsed as Integer.", header);
                 }
             }
         }

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/Configs.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/Configs.java
@@ -360,6 +360,15 @@ public class Configs {
     private static final String HTTP2_MAX_CONCURRENT_STREAMS = "COSMOS.HTTP2_MAX_CONCURRENT_STREAMS";
     private static final String HTTP2_MAX_CONCURRENT_STREAMS_VARIABLE = "COSMOS_HTTP2_MAX_CONCURRENT_STREAMS";
 
+    // Config to indicate the max page size for partition key range read feed operation if not already configured through CosmosQueryRequestOptions
+    private static final int DEFAULT_PK_RANGE_READ_FEED_PAGE_SIZE = 100;
+    private static final String PK_RANGE_READ_FEED_PAGE_SIZE = "COSMOS.PK_RANGE_READ_FEED_PAGE_SIZE";
+    private static final String PK_RANGE_READ_FEED_PAGE_SIZE_VARIABLE = "COSMOS_PK_RANGE_READ_FEED_PAGE_SIZE";
+
+    private static final boolean DEFAULT_PK_RANGE_PREFETCHING_ENABLED = false;
+    private static final String PK_RANGE_PREFETCHING_ENABLED = "COSMOS.PK_RANGE_PREFETCHING_ENABLED";
+    private static final String PK_RANGE_PREFETCHING_ENABLED_VARIABLE = "COSMOS_PK_RANGE_PREFETCHING_ENABLED";
+
     public static final String APPLICATIONINSIGHTS_CONNECTION_STRING = "applicationinsights.connection.string";
     public static final String APPLICATIONINSIGHTS_CONNECTION_STRING_VARIABLE = "APPLICATIONINSIGHTS_CONNECTION_STRING";
 
@@ -1218,6 +1227,26 @@ public class Configs {
                 String.valueOf(DEFAULT_WARN_LEVEL_LOGGING_THRESHOLD_FOR_PPAF)));
 
         return Integer.parseInt(warnLevelLoggingThresholdForPpaf);
+    }
+
+    public static int getPartitionKeyRangesReadFeedPageSize() {
+        String pkRangeReadFeedPageSize = System.getProperty(
+            PK_RANGE_READ_FEED_PAGE_SIZE,
+            firstNonNull(
+                emptyToNull(System.getenv().get(PK_RANGE_READ_FEED_PAGE_SIZE_VARIABLE)),
+                String.valueOf(DEFAULT_PK_RANGE_READ_FEED_PAGE_SIZE)));
+
+        return Integer.parseInt(pkRangeReadFeedPageSize);
+    }
+
+    public static boolean isPartitionKeyRangePrefetchingEnabled() {
+        String isPkRangePrefetchEnabled = System.getProperty(
+            PK_RANGE_PREFETCHING_ENABLED,
+            firstNonNull(
+                emptyToNull(System.getenv().get(PK_RANGE_PREFETCHING_ENABLED_VARIABLE)),
+                String.valueOf(DEFAULT_PK_RANGE_PREFETCHING_ENABLED)));
+
+        return Boolean.parseBoolean(isPkRangePrefetchEnabled);
     }
 
     public static String getAzureMonitorConnectionString() {

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/CosmosQueryRequestOptionsImpl.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/CosmosQueryRequestOptionsImpl.java
@@ -32,6 +32,7 @@ public final class CosmosQueryRequestOptionsImpl extends CosmosQueryRequestOptio
     private Integer maxItemCountForHybridSearch;
     private List<CosmosDiagnostics> cancelledRequestDiagnosticsTracker = new ArrayList<>();
     private String collectionRid;
+    private String operationId;
 
     /**
      * Instantiates a new query request options.
@@ -72,6 +73,7 @@ public final class CosmosQueryRequestOptionsImpl extends CosmosQueryRequestOptio
         this.maxItemCountForVectorSearch = options.maxItemCountForVectorSearch;
         this.maxItemCountForHybridSearch = options.maxItemCountForHybridSearch;
         this.collectionRid = options.collectionRid;
+        this.operationId = options.operationId;
     }
 
     /**
@@ -407,5 +409,13 @@ public final class CosmosQueryRequestOptionsImpl extends CosmosQueryRequestOptio
 
     public void setCollectionRid(String collectionRid) {
         this.collectionRid = collectionRid;
+    }
+
+    public String getOperationId() {
+        return operationId;
+    }
+
+    public void setOperationId(String operationId) {
+        this.operationId = operationId;
     }
 }

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/ImplementationBridgeHelpers.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/ImplementationBridgeHelpers.java
@@ -313,6 +313,9 @@ public class ImplementationBridgeHelpers {
             String getCollectionRid(CosmosQueryRequestOptions options);
             Map<String, Object> getProperties(CosmosQueryRequestOptions options);
             Map<String, String> getHeaders(CosmosQueryRequestOptions options);
+
+            void setOperationId(CosmosQueryRequestOptions options, String operationId);
+            String getOperationId(CosmosQueryRequestOptions options);
         }
     }
 

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/RequestOptions.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/RequestOptions.java
@@ -66,6 +66,7 @@ public class RequestOptions implements OverridableRequestOptions {
     private Set<String> keywordIdentifiers;
 
     private PartitionKeyDefinition partitionKeyDefinition;
+    private String operationId;
 
     public RequestOptions() {
 
@@ -123,6 +124,10 @@ public class RequestOptions implements OverridableRequestOptions {
 
         if (toBeCloned.keywordIdentifiers != null) {
             this.keywordIdentifiers = new HashSet<>(toBeCloned.keywordIdentifiers);
+        }
+
+        if (toBeCloned.operationId != null) {
+            this.operationId = toBeCloned.operationId;
         }
     }
 
@@ -706,5 +711,13 @@ public class RequestOptions implements OverridableRequestOptions {
 
     public PartitionKeyDefinition getPartitionKeyDefinition() {
         return this.partitionKeyDefinition;
+    }
+
+    public String getOperationId() {
+        return operationId;
+    }
+
+    public void setOperationId(String operationId) {
+        this.operationId = operationId;
     }
 }

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/ResourceThrottleRetryPolicy.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/ResourceThrottleRetryPolicy.java
@@ -86,6 +86,15 @@ public class ResourceThrottleRetryPolicy extends DocumentClientRetryPolicy {
         if (this.currentAttemptCount < this.maxAttemptCount &&
                 (retryDelay = checkIfRetryNeeded(dce)) != null) {
             this.currentAttemptCount++;
+
+            logger.warn(
+                "Operation will be retried after {} milliseconds. Current attempt {}, Cumulative delay {} for statusCode {} and subStatusCode {}",
+                retryDelay.toMillis(),
+                this.currentAttemptCount,
+                this.cumulativeRetryDelay,
+                dce.getStatusCode(),
+                dce.getSubStatusCode());
+
             logger.debug(
                     "Operation will be retried after {} milliseconds. Current attempt {}, Cumulative delay {}",
                     retryDelay.toMillis(),
@@ -141,6 +150,7 @@ public class ResourceThrottleRetryPolicy extends DocumentClientRetryPolicy {
                     // There is no server returned retryAfter
                     if (Exceptions.isSubStatusCode(dce, HttpConstants.SubStatusCodes.USER_REQUEST_RATE_TOO_LARGE)) {
                         // for 429/3200, server should have returned retry after. If not, then retry immediately
+                        logger.warn("No retryAfter returned by server in 429/3200, retrying immediately");
                         retryDelay = DEFAULT_RETRY_IN_SECONDS_FOR_3200;
                     } else {
                         // retryAfter will not always be returned, for example 429/3089

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/ResourceThrottleRetryPolicy.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/ResourceThrottleRetryPolicy.java
@@ -90,12 +90,8 @@ public class ResourceThrottleRetryPolicy extends DocumentClientRetryPolicy {
                 (retryDelay = checkIfRetryNeeded(dce)) != null) {
             this.currentAttemptCount++;
 
-            Optional<CosmosDiagnosticsContext> cosmosDiagnosticsContext = resolveDiagnosticsContext(dce);
-
             logger.warn(
-                "OperationType {} for ResourceType {} will be retried after {} milliseconds. Current attempt {}, Cumulative delay {} for statusCode {} and subStatusCode {}",
-                cosmosDiagnosticsContext.isPresent() ? cosmosDiagnosticsContext.get().getOperationType() : "N/A",
-                cosmosDiagnosticsContext.isPresent() ? cosmosDiagnosticsContext.get().getResourceType() : "N/A",
+                "Operation will be retried after {} milliseconds. Current attempt {}, Cumulative delay {} for statusCode {} and subStatusCode {}",
                 retryDelay.toMillis(),
                 this.currentAttemptCount,
                 this.cumulativeRetryDelay,
@@ -175,12 +171,5 @@ public class ResourceThrottleRetryPolicy extends DocumentClientRetryPolicy {
         }
         // if retry not needed returns null
         return null;
-    }
-
-    public Optional<CosmosDiagnosticsContext> resolveDiagnosticsContext(CosmosException dce) {
-        if (dce != null && dce.getDiagnostics() != null) {
-            return Optional.ofNullable(dce.getDiagnostics().getDiagnosticsContext());
-        }
-        return Optional.empty();
     }
 }

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/RxDocumentClientImpl.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/RxDocumentClientImpl.java
@@ -4831,7 +4831,9 @@ public class RxDocumentClientImpl implements AsyncDocumentClient, IAuthorization
     }
 
     @Override
-    public Flux<FeedResponse<PartitionKeyRange>> readPartitionKeyRanges(String collectionLink, CosmosQueryRequestOptions options) {
+    public Flux<FeedResponse<PartitionKeyRange>> readPartitionKeyRanges(
+        String collectionLink,
+        CosmosQueryRequestOptions options) {
         if (StringUtils.isEmpty(collectionLink)) {
             throw new IllegalArgumentException("collectionLink");
         }
@@ -6152,7 +6154,11 @@ public class RxDocumentClientImpl implements AsyncDocumentClient, IAuthorization
         Integer maxItemCount = ModelBridgeInternal.getMaxItemCountFromQueryRequestOptions(nonNullOptions);
         int maxPageSize = maxItemCount != null ? maxItemCount : -1;
 
-        logger.warn("ReadFeed call made for ResourceType : [{}] and ResourceLink : [{}] with pageSize : [{}] for UserAgent : [{}]", resourceType, resourceLink, maxPageSize, this.userAgentContainer.getUserAgent());
+        if (ResourceType.PartitionKeyRange.equals(resourceType)) {
+            maxPageSize = (maxPageSize == -1) ? Configs.getPartitionKeyRangesReadFeedPageSize() : maxPageSize;
+        }
+
+        logger.warn("ReadFeed call made for ResourceType : [{}] and ResourceLink : [{}] with pageSize : [{}] for UserAgent : [{}] and CallIdentifier : [{}]", resourceType, resourceLink, maxPageSize, this.userAgentContainer.getUserAgent(), qryOptAccessor.getOperationId(nonNullOptions));
 
         assert(resourceType != ResourceType.Document);
         // readFeed is only used for non-document operations - no need to wire up hedging

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/RxDocumentClientImpl.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/RxDocumentClientImpl.java
@@ -6155,7 +6155,7 @@ public class RxDocumentClientImpl implements AsyncDocumentClient, IAuthorization
         int maxPageSize = maxItemCount != null ? maxItemCount : -1;
 
         if (ResourceType.PartitionKeyRange.equals(resourceType)) {
-            maxPageSize = (maxPageSize == -1) ? Configs.getPartitionKeyRangesReadFeedPageSize() : maxPageSize;
+            maxPageSize = Configs.getPartitionKeyRangesReadFeedPageSize();
         }
 
         assert(resourceType != ResourceType.Document);

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/RxDocumentClientImpl.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/RxDocumentClientImpl.java
@@ -6555,6 +6555,9 @@ public class RxDocumentClientImpl implements AsyncDocumentClient, IAuthorization
                 return Mono.error(new IllegalStateException("Collection cannot be null"));
             }
 
+            StringBuilder sb = new StringBuilder();
+            sb.append("RxDocumentClientImpl.getFeedRanges").append(",");
+
             Mono<Utils.ValueHolder<List<PartitionKeyRange>>> valueHolderMono = partitionKeyRangeCache
                 .tryGetOverlappingRangesAsync(
                     BridgeInternal.getMetaDataDiagnosticContext(request.requestContext.cosmosDiagnostics),
@@ -6562,7 +6565,7 @@ public class RxDocumentClientImpl implements AsyncDocumentClient, IAuthorization
                     RANGE_INCLUDING_ALL_PARTITION_KEY_RANGES,
                     forceRefresh,
                     null,
-                    new StringBuilder());
+                    sb);
 
             return valueHolderMono.map(partitionKeyRangeList -> toFeedRanges(partitionKeyRangeList, request));
         });

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/RxGatewayStoreModel.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/RxGatewayStoreModel.java
@@ -797,12 +797,12 @@ public class RxGatewayStoreModel implements RxStoreModel, HttpTransportSerialize
         MetadataDiagnosticsContext metadataCtx = BridgeInternal
             .getMetaDataDiagnosticContext(request.requestContext.cosmosDiagnostics);
 
-        if (pkRangeId.getCollectionRid() != null) {
-            return resolvePartitionKeyRangeByPkRangeIdCore(pkRangeId, pkRangeId.getCollectionRid(), metadataCtx, new StringBuilder());
-        }
-
         StringBuilder sb = new StringBuilder();
         sb.append("RxGatewayStoreModel.resolvePartitionKeyRangeByPkRangeId:").append(",");
+
+        if (pkRangeId.getCollectionRid() != null) {
+            return resolvePartitionKeyRangeByPkRangeIdCore(pkRangeId, pkRangeId.getCollectionRid(), metadataCtx, sb);
+        }
 
         return this.collectionCache.resolveCollectionAsync(
             metadataCtx,

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/batch/BulkOperationRetryPolicy.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/batch/BulkOperationRetryPolicy.java
@@ -123,7 +123,7 @@ final class BulkOperationRetryPolicy implements IRetryPolicy {
                                                                                     .getRange(),
                                                                                 true,
                                                                                 null /*properties*/,
-                                                      new StringBuilder())
+                                                      sb)
                                                   .then(Mono.just(true)));
             }
 

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/batch/BulkOperationRetryPolicy.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/batch/BulkOperationRetryPolicy.java
@@ -110,6 +110,10 @@ final class BulkOperationRetryPolicy implements IRetryPolicy {
             if ((subStatusCode == SubStatusCodes.PARTITION_KEY_RANGE_GONE ||
                      subStatusCode == SubStatusCodes.COMPLETING_SPLIT_OR_MERGE ||
                      subStatusCode == SubStatusCodes.COMPLETING_PARTITION_MIGRATION)) {
+
+                StringBuilder sb = new StringBuilder();
+                sb.append("BulkOperationRetryPolicy.shouldRetryInMainSink").append(",");
+
                 return collectionCache
                        .resolveByNameAsync(null, collectionLink, null)
                        .flatMap(collection -> this.partitionKeyRangeCache

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/caches/AsyncCacheNonBlocking.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/caches/AsyncCacheNonBlocking.java
@@ -84,11 +84,11 @@ public class AsyncCacheNonBlocking<TKey, TValue> {
 
             return initialLazyValue.getValueAsync().flatMap(value -> {
                 if (!forceRefresh.apply(value)) {
-                    logger.warn("cache[{}] value found without forceRefresh requirement", key);
+                    logger.warn("cache[{}] value found without forceRefresh requirement with callIdentifier [{}]", key, callIdentifier);
                     return Mono.just(value);
                 }
 
-                logger.warn("cache[{}] value found but with forceRefresh requirement", key);
+                logger.warn("cache[{}] value found but with forceRefresh requirement with callIdentifier [{}]", key, callIdentifier);
 
                 Mono<TValue> refreshMono = initialLazyValue.getOrCreateBackgroundRefreshTaskAsync(singleValueInitFunc);
 

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/caches/AsyncCacheNonBlocking.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/caches/AsyncCacheNonBlocking.java
@@ -5,6 +5,7 @@ package com.azure.cosmos.implementation.caches;
 import com.azure.cosmos.CosmosException;
 import com.azure.cosmos.implementation.CosmosSchedulers;
 import com.azure.cosmos.implementation.Exceptions;
+import com.azure.cosmos.implementation.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Mono;
@@ -71,19 +72,23 @@ public class AsyncCacheNonBlocking<TKey, TValue> {
     public Mono<TValue> getAsync(
         TKey key,
         Function<TValue, Mono<TValue>> singleValueInitFunc,
-        Function<TValue, Boolean> forceRefresh) {
-        return Mono.fromFuture(() -> getAsyncInternal(key, singleValueInitFunc, forceRefresh).toFuture(), true);
+        Function<TValue, Boolean> forceRefresh,
+        String callIdentifier) {
+        return Mono.fromFuture(() -> getAsyncInternal(key, singleValueInitFunc, forceRefresh, callIdentifier).toFuture(), true);
     }
 
-    private Mono<TValue> getAsyncInternal(TKey key, Function<TValue, Mono<TValue>> singleValueInitFunc, Function<TValue, Boolean> forceRefresh) {
+    private Mono<TValue> getAsyncInternal(TKey key, Function<TValue, Mono<TValue>> singleValueInitFunc, Function<TValue, Boolean> forceRefresh, String callIdentifier) {
         AsyncLazyWithRefresh<TValue> initialLazyValue = values.get(key);
         if (initialLazyValue != null) {
             logger.debug("cache[{}] exists", key);
 
             return initialLazyValue.getValueAsync().flatMap(value -> {
                 if (!forceRefresh.apply(value)) {
+                    logger.warn("cache[{}] value found without forceRefresh requirement", key);
                     return Mono.just(value);
                 }
+
+                logger.warn("cache[{}] value found but with forceRefresh requirement", key);
 
                 Mono<TValue> refreshMono = initialLazyValue.getOrCreateBackgroundRefreshTaskAsync(singleValueInitFunc);
 
@@ -96,6 +101,13 @@ public class AsyncCacheNonBlocking<TKey, TValue> {
                             }
                         }
 
+                        if (exception instanceof CosmosException) {
+                            CosmosException cosmosException = Utils.as(exception, CosmosException.class);
+                            logger.warn("backgroundRefreshTaskAsync [key exists] error for cache[{}] resulted in error with statusCode : [{}] and subStatusCode : [{}] and callIdentifier : [{}]", key, cosmosException.getStatusCode(), cosmosException.getSubStatusCode(), callIdentifier);
+                        } else {
+                            logger.warn("backgroundRefreshTaskAsync [key exists] error for cache[{}] resulted in error with message : [{}] and callIdentifier : [{}]", key, exception.getMessage(), callIdentifier);
+                        }
+
                         logger.debug("refresh cache [{}] resulted in error", key, exception);
                         return Mono.error(exception);
                     }
@@ -104,12 +116,20 @@ public class AsyncCacheNonBlocking<TKey, TValue> {
                 if (initialLazyValue.shouldRemoveFromCache()) {
                     this.remove(key);
                 }
+
+                if (exception instanceof CosmosException) {
+                    CosmosException cosmosException = Utils.as(exception, CosmosException.class);
+                    logger.warn("initialLazyValue.getValueAsync [key exists] error for cache[{}] resulted in error with statusCode : [{}] and subsStatusCode : [{}]", key, cosmosException.getStatusCode(), cosmosException.getSubStatusCode());
+                } else {
+                    logger.warn("initialLazyValue.getValueAsync [key exists] error for cache[{}] resulted in error with message : [{}]", key, exception.getMessage());
+                }
+
                 logger.debug("cache[{}] resulted in error", key, exception);
                 return Mono.error(exception);
             });
         }
 
-        logger.debug("cache[{}] doesn't exist, computing new value", key);
+        logger.warn("cache[{}] doesn't exist, computing new value", key);
         AsyncLazyWithRefresh<TValue> asyncLazyWithRefresh = new AsyncLazyWithRefresh<TValue>(singleValueInitFunc);
         AsyncLazyWithRefresh<TValue> preResult = this.values.putIfAbsent(key, asyncLazyWithRefresh);
         if (preResult == null) {
@@ -123,6 +143,14 @@ public class AsyncCacheNonBlocking<TKey, TValue> {
                 if (result.shouldRemoveFromCache()) {
                     this.remove(key);
                 }
+
+                if (exception instanceof CosmosException) {
+                    CosmosException cosmosException = Utils.as(exception, CosmosException.class);
+                    logger.warn("result.getValueAsync [key does not exist] error for cache[{}] resulted in error with statusCode : [{}] and subsStatusCode : [{}] and callIdentifier : [{}]", key, cosmosException.getStatusCode(), cosmosException.getSubStatusCode(), callIdentifier);
+                } else {
+                    logger.warn("result.getValueAsync [key does not exist] error for cache[{}] resulted in error with message : [{}] and callIdentifier : [{}]", key, exception.getMessage(), callIdentifier);
+                }
+
                 logger.debug("cache[{}] resulted in error", key, exception);
                 return Mono.error(exception);
             }

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/caches/RxPartitionKeyRangeCache.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/caches/RxPartitionKeyRangeCache.java
@@ -310,7 +310,9 @@ public class RxPartitionKeyRangeCache implements IPartitionKeyRangeCache {
             qryOptAccessor.setOperationId(cosmosQueryRequestOptions, callIdentifier);
             Instant addressCallStartTime = Instant.now();
 
-            logger.warn("Reading PartitionKeyRanges for collection : [{}] with rid : [{}] by UserAgent : [{}] by CallPath : [{}] by CallIdentifier [{}]", coll.getId(), collectionRid, this.client.getUserAgent(), sb != null ? sb.toString() : "N/A", callIdentifier);
+            int prefetch = Configs.isPartitionKeyRangePrefetchingEnabled() ? Queues.XS_BUFFER_SIZE : 1;
+
+            logger.warn("Reading PartitionKeyRanges for collection : [{}] with rid : [{}] by UserAgent : [{}] by CallPath : [{}] by CallIdentifier [{}] with Prefetch [{}]", coll.getId(), collectionRid, this.client.getUserAgent(), sb != null ? sb.toString() : "N/A", callIdentifier, prefetch);
 
             return client.readPartitionKeyRanges(coll.getSelfLink(), cosmosQueryRequestOptions)
                 // maxConcurrent = 1 to makes it in the right getOrder
@@ -324,7 +326,7 @@ public class RxPartitionKeyRangeCache implements IPartitionKeyRangeCache {
                     }
 
                     return Flux.fromIterable(p.getResults());
-                }, 1, Configs.isPartitionKeyRangePrefetchingEnabled() ? Queues.XS_BUFFER_SIZE : 1).collectList();
+                }, 1, prefetch).collectList();
         });
     }
 }

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/directconnectivity/GlobalAddressResolver.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/directconnectivity/GlobalAddressResolver.java
@@ -124,13 +124,16 @@ public class GlobalAddressResolver implements IAddressResolver {
                             return Flux.empty();
                         }
 
+                        StringBuilder sb = new StringBuilder();
+                        sb.append("GlobalAddressResolver:submitOpenConnectionTasksAndInitCaches").append(",");
+
                         return this.routingMapProvider.tryGetOverlappingRangesAsync(
                                 null,
                                 collection.getResourceId(),
                                 PartitionKeyInternalHelper.FullRange,
                                 true,
                                 null,
-                                new StringBuilder())
+                                sb)
                             .flatMap(valueHolder -> {
 
                                 String containerLink = ImplementationBridgeHelpers

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/feedranges/FeedRangeCompositeContinuationImpl.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/feedranges/FeedRangeCompositeContinuationImpl.java
@@ -505,6 +505,9 @@ final class FeedRangeCompositeContinuationImpl extends FeedRangeContinuation {
         Range<String> effectiveRange,
         final Boolean forceRefresh) {
 
+        StringBuilder sb = new StringBuilder();
+        sb.append("FeedRangeCompositeContinuationImpl.tryGetOverlappingRanges").append(",");
+
         return partitionKeyRangeCache.tryGetOverlappingRangesAsync(
                 null,
                 this.getContainerRid(),

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/feedranges/FeedRangeCompositeContinuationImpl.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/feedranges/FeedRangeCompositeContinuationImpl.java
@@ -514,7 +514,7 @@ final class FeedRangeCompositeContinuationImpl extends FeedRangeContinuation {
                 effectiveRange,
                 forceRefresh,
                 null,
-            new StringBuilder());
+            sb);
     }
 
     private static CompositeContinuationToken tryParseAsCompositeContinuationToken(

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/feedranges/FeedRangeEpkImpl.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/feedranges/FeedRangeEpkImpl.java
@@ -107,6 +107,8 @@ public final class FeedRangeEpkImpl extends FeedRangeInternal {
                 }
 
                 final String containerRid = collection.getResourceId();
+                StringBuilder sb = new StringBuilder();
+                sb.append("FeedRangeEpkImpl.getPartitionKeyRanges").append(",");
 
                 return routingMapProvider
                     .tryGetOverlappingRangesAsync(

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/feedranges/FeedRangePartitionKeyImpl.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/feedranges/FeedRangePartitionKeyImpl.java
@@ -134,7 +134,7 @@ public final class FeedRangePartitionKeyImpl extends FeedRangeInternal {
                         Range.getPointRange(effectivePartitionKey),
                         false,
                         null,
-                        new StringBuilder())
+                        sb)
                     .flatMap(pkRangeHolder -> {
                         ArrayList<String> rangeList = new ArrayList<>(1);
 

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/feedranges/FeedRangePartitionKeyImpl.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/feedranges/FeedRangePartitionKeyImpl.java
@@ -124,6 +124,9 @@ public final class FeedRangePartitionKeyImpl extends FeedRangeInternal {
                     this.partitionKey,
                     collection.getPartitionKey());
 
+                StringBuilder sb = new StringBuilder();
+                sb.append("FeedRangePartitionKeyImpl.getPartitionKeyRanges").append(",");
+
                 return routingMapProvider
                     .tryGetOverlappingRangesAsync(
                         metadataDiagnosticsCtx,

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/query/DefaultDocumentQueryExecutionContext.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/query/DefaultDocumentQueryExecutionContext.java
@@ -148,13 +148,16 @@ public class DefaultDocumentQueryExecutionContext<T> extends DocumentQueryExecut
 
     public Mono<List<PartitionKeyRange>> getTargetPartitionKeyRangesById(String resourceId,
                                                                                       String partitionKeyRangeIdInternal) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("DefaultDocumentQueryExecutionContext.getTargetPartitionKeyRangesById").append(",");
+
         return client.getPartitionKeyRangeCache()
                    .tryGetPartitionKeyRangeByIdAsync(null,
                                                      resourceId,
                                                      partitionKeyRangeIdInternal,
                                                      false,
                                                      null,
-                       new StringBuilder())
+                       sb)
                    .flatMap(partitionKeyRange -> Mono.just(Collections.singletonList(partitionKeyRange.v)));
     }
 

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/query/DocumentProducer.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/query/DocumentProducer.java
@@ -326,13 +326,17 @@ class DocumentProducer<T> {
     }
 
     private Mono<Utils.ValueHolder<List<PartitionKeyRange>>> getReplacementRanges(Range<String> range) {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("DocumentProducer.getReplacementRanges").append(",");
+
         return client.getPartitionKeyRangeCache().tryGetOverlappingRangesAsync(
             null,
             collectionRid,
             range,
             true,
             qryOptionsAccessor.getProperties(cosmosQueryRequestOptions),
-            new StringBuilder());
+            sb);
     }
 
     private boolean isSplitOrMerge(CosmosException e) {

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/routing/RoutingMapProviderHelper.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/routing/RoutingMapProviderHelper.java
@@ -125,7 +125,7 @@ public final class RoutingMapProviderHelper {
             StringBuilder sb = new StringBuilder();
             sb.append("RoutingMapProviderHelper.getOverlappingRanges").append(",");
 
-            return routingMapProvider.tryGetOverlappingRangesAsync(null, resourceId, queryRange, false, null, new StringBuilder())
+            return routingMapProvider.tryGetOverlappingRangesAsync(null, resourceId, queryRange, false, null, sb)
                        .map(ranges -> ranges.v != null ? ranges.v : new ArrayList<PartitionKeyRange>())
                        .map(targetRanges::addAll)
                        .flatMap(aBoolean -> {

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/routing/RoutingMapProviderHelper.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/routing/RoutingMapProviderHelper.java
@@ -122,6 +122,9 @@ public final class RoutingMapProviderHelper {
                 queryRange = sortedRange;
             }
 
+            StringBuilder sb = new StringBuilder();
+            sb.append("RoutingMapProviderHelper.getOverlappingRanges").append(",");
+
             return routingMapProvider.tryGetOverlappingRangesAsync(null, resourceId, queryRange, false, null, new StringBuilder())
                        .map(ranges -> ranges.v != null ? ranges.v : new ArrayList<PartitionKeyRange>())
                        .map(targetRanges::addAll)

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/throughputControl/sdk/controller/request/PkRangesThroughputRequestController.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/throughputControl/sdk/controller/request/PkRangesThroughputRequestController.java
@@ -121,8 +121,10 @@ public class PkRangesThroughputRequestController implements IThroughputRequestCo
     private Mono<List<PartitionKeyRange>> getPartitionKeyRanges(Range<String> range) {
         checkNotNull(range, "Range can not be null");
         // TODO: add diagnostics context
+        StringBuilder sb = new StringBuilder();
+        sb.append("PkRangesThroughputRequestController.getPartitionKeyRanges").append(",");
         return this.partitionKeyRangeCache
-            .tryGetOverlappingRangesAsync(null, this.targetContainerRid, range, true, null, new StringBuilder())
+            .tryGetOverlappingRangesAsync(null, this.targetContainerRid, range, true, null, sb)
             .map(partitionKeyRangesValueHolder -> partitionKeyRangesValueHolder.v);
     }
 }

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/models/CosmosQueryRequestOptions.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/models/CosmosQueryRequestOptions.java
@@ -13,6 +13,7 @@ import com.azure.cosmos.implementation.CosmosQueryRequestOptionsBase;
 import com.azure.cosmos.implementation.CosmosQueryRequestOptionsImpl;
 import com.azure.cosmos.implementation.ImplementationBridgeHelpers;
 import com.azure.cosmos.implementation.RequestOptions;
+import com.azure.cosmos.implementation.apachecommons.lang.StringUtils;
 import com.azure.cosmos.util.Beta;
 
 import java.time.Duration;
@@ -724,6 +725,24 @@ public class CosmosQueryRequestOptions {
                     }
 
                     return options.getImpl().getHeaders();
+                }
+
+                @Override
+                public void setOperationId(CosmosQueryRequestOptions options, String operationId) {
+                    if (options == null || options.actualRequestOptions == null) {
+                        return;
+                    }
+
+                    options.actualRequestOptions.setOperationId(operationId);
+                }
+
+                @Override
+                public String getOperationId(CosmosQueryRequestOptions options) {
+                    if (options == null || options.actualRequestOptions == null || options.actualRequestOptions.getOperationId() == null) {
+                        return StringUtils.EMPTY;
+                    }
+
+                    return options.actualRequestOptions.getOperationId();
                 }
             });
     }

--- a/sdk/cosmos/azure-cosmos/src/main/java/module-info.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/module-info.java
@@ -26,7 +26,6 @@ module com.azure.cosmos {
     //  This is only required by guava shaded libraries
     requires java.logging;
 	requires HdrHistogram;
-    requires reactor.core;
 
     // public API surface area
     exports com.azure.cosmos;

--- a/sdk/cosmos/azure-cosmos/src/main/java/module-info.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/module-info.java
@@ -26,6 +26,7 @@ module com.azure.cosmos {
     //  This is only required by guava shaded libraries
     requires java.logging;
 	requires HdrHistogram;
+    requires reactor.core;
 
     // public API surface area
     exports com.azure.cosmos;


### PR DESCRIPTION
# Main Changes

- Add the following JVM configs and their defaults. Below property sets the page size to 100 by default for `ReadFeed` of `PartitionKeyRange` calls:
`COSMOS.PK_RANGE_READ_FEED_PAGE_SIZE`: **100**
`COSMOS_PK_RANGE_READ_FEED_PAGE_SIZE`: **100**

- Add the following environment variables and their defaults. Below property sets the prefetch for `ReadFeed` of `PartitionKeyRange` calls to **1** (minimum possible value):
`COSMOS.PK_RANGE_PREFETCHING_ENABLED`: `false`
`COSMOS_PK_RANGE_PREFETCHING_ENABLED`: `false`

# Relevant logs

```java
2025-09-16 21:56:29,738       [main] INFO  com.azure.cosmos.TestNGLogListener - beforeInvocation: IncrementalChangeFeedProcessorTest#readFeedDocumentsStartFromBeginningWithPkRangeThrottles
2025-09-16 21:56:29,752       [TestNG-method=readFeedDocumentsStartFromBeginningWithPkRangeThrottles-1] WARN  com.azure.cosmos.implementation.changefeed.pkversion.IncrementalChangeFeedProcessorImpl - Found lower than expected setting for leaseAcquireInterval
2025-09-16 21:56:30,305       [transport-response-bounded-elastic-1] WARN  com.azure.cosmos.implementation.caches.AsyncCacheNonBlocking - cache[LncIALngHpg=] doesn't exist, computing new value
2025-09-16 21:56:30,311       [transport-response-bounded-elastic-1] WARN  com.azure.cosmos.implementation.caches.RxPartitionKeyRangeCache - Reading PartitionKeyRanges for collection : [TestLeaseContainer] with rid : [LncIALngHpg=] by UserAgent : [azsdk-java-cosmos/4.74.0 Windows11/10.0 JRE/21.0.8] by CallPath : [RxDocumentClientImpl.readDocumentInternal:,RxPartitionKeyRangeCache.TryLookupAsync:,RxPartitionKeyRangeCache.GetRoutingMapForCollectionAsync:,RxPartitionKeyRangeCache.GetPartitionKeyRange:LncIALngHpg=,] by CallIdentifier [240c5119-fa55-4f41-a89d-eba52ac729f6] with Prefetch [1]
2025-09-16 21:56:30,327       [transport-response-bounded-elastic-1] WARN  com.azure.cosmos.implementation.RxDocumentClientImpl - ReadFeed call made for ResourceType : [PartitionKeyRange] and ResourceLink : [/dbs/LncIAA==/colls/LncIALngHpg=/pkranges/] with pageSize : [100] for UserAgent : [azsdk-java-cosmos/4.74.0 Windows11/10.0 JRE/21.0.8] and CallIdentifier : [240c5119-fa55-4f41-a89d-eba52ac729f6]
2025-09-16 21:56:30,394       [transport-response-bounded-elastic-1] WARN  com.azure.cosmos.implementation.caches.AsyncCacheNonBlocking - cache[LncIALngHpg=] value found without forceRefresh requirement with callIdentifier [46276215-5393-4ccf-8f2d-d04643be4f48]
2025-09-16 21:56:30,472       [transport-response-bounded-elastic-1] INFO  com.azure.cosmos.implementation.SessionContainer - Registering a new collection resourceId [LncIALngHpg=] in SessionTokens
2025-09-16 21:56:30,503       [boundedElastic-3] WARN  com.azure.cosmos.implementation.caches.AsyncCacheNonBlocking - cache[LncIALngHpg=] value found without forceRefresh requirement with callIdentifier [6b674c4c-0a64-44c2-a297-d7ab5fee0749]
2025-09-16 21:56:30,552       [transport-response-bounded-elastic-1] WARN  com.azure.cosmos.implementation.caches.AsyncCacheNonBlocking - cache[LncIALngHpg=] value found without forceRefresh requirement with callIdentifier [fb601460-d092-43bd-be8d-2a57c0a4db1c]
2025-09-16 21:56:30,556       [transport-response-bounded-elastic-1] WARN  com.azure.cosmos.implementation.caches.AsyncCacheNonBlocking - cache[LncIALngHpg=] value found without forceRefresh requirement with callIdentifier [fbc8c5a6-b95d-49ca-804c-1428c9713975]
2025-09-16 21:56:30,599       [transport-response-bounded-elastic-1] WARN  com.azure.cosmos.implementation.caches.AsyncCacheNonBlocking - cache[LncIALngHpg=] value found without forceRefresh requirement with callIdentifier [1f961d59-d9d9-4584-82a1-1e27262fab0c]
2025-09-16 21:56:30,601       [transport-response-bounded-elastic-1] WARN  com.azure.cosmos.implementation.caches.AsyncCacheNonBlocking - cache[LncIALngHpg=] value found without forceRefresh requirement with callIdentifier [3fb9b56e-546b-427c-862f-2e88cf66129f]
2025-09-16 21:56:30,654       [boundedElastic-4] WARN  com.azure.cosmos.implementation.caches.AsyncCacheNonBlocking - cache[LncIALngHpg=] value found without forceRefresh requirement with callIdentifier [d8f9d916-16ca-412e-b447-b1ed00b0c5ad]
2025-09-16 21:56:30,693       [transport-response-bounded-elastic-1] WARN  com.azure.cosmos.implementation.caches.AsyncCacheNonBlocking - cache[LncIALngHpg=] value found without forceRefresh requirement with callIdentifier [ebf8bf21-5591-4a1c-81fd-a9a81e0f1ba7]
2025-09-16 21:56:30,693       [transport-response-bounded-elastic-1] WARN  com.azure.cosmos.implementation.caches.AsyncCacheNonBlocking - cache[LncIALngHpg=] value found without forceRefresh requirement with callIdentifier [b108aa85-d9dc-4c12-9abd-309593a381a6]
2025-09-16 21:56:30,696       [transport-response-bounded-elastic-1] WARN  com.azure.cosmos.implementation.caches.AsyncCacheNonBlocking - cache[LncIALngHpg=] value found without forceRefresh requirement with callIdentifier [bef41182-d38a-4835-b0b1-b41a0e193cfd]
2025-09-16 21:56:30,696       [transport-response-bounded-elastic-1] WARN  com.azure.cosmos.implementation.caches.AsyncCacheNonBlocking - cache[LncIALngHpg=] value found without forceRefresh requirement with callIdentifier [89051c6c-ae0d-4e2b-9b74-6a8a5aba12e4]
2025-09-16 21:56:30,742       [boundedElastic-4] WARN  com.azure.cosmos.implementation.caches.AsyncCacheNonBlocking - cache[LncIALngHpg=] value found without forceRefresh requirement with callIdentifier [1d205354-c070-40b2-8766-14c521fec5f6]
2025-09-16 21:56:30,779       [transport-response-bounded-elastic-1] WARN  com.azure.cosmos.implementation.caches.AsyncCacheNonBlocking - cache[LncIALngHpg=] value found without forceRefresh requirement with callIdentifier [5be50bd1-ee77-4f03-bcc9-773922405d9b]
2025-09-16 21:56:30,779       [transport-response-bounded-elastic-1] WARN  com.azure.cosmos.implementation.caches.AsyncCacheNonBlocking - cache[LncIALngHpg=] value found without forceRefresh requirement with callIdentifier [c6e78b25-1123-4fe4-8924-48654673b9ed]
2025-09-16 21:56:30,781       [transport-response-bounded-elastic-1] WARN  com.azure.cosmos.implementation.caches.AsyncCacheNonBlocking - cache[LncIALngHpg=] value found without forceRefresh requirement with callIdentifier [638e13cf-c428-4d40-92c9-05ffa09004d7]
2025-09-16 21:56:30,784       [transport-response-bounded-elastic-1] WARN  com.azure.cosmos.implementation.caches.AsyncCacheNonBlocking - cache[LncIALngHpg=] value found without forceRefresh requirement with callIdentifier [d1cafd7f-cbdc-4800-8ab9-aa06c3ec7564]
2025-09-16 21:56:30,826       [boundedElastic-3] INFO  com.azure.cosmos.implementation.changefeed.common.EqualPartitionsBalancingStrategy - Found unused or expired lease 0 (owner was YqSwbT); previous lease count for instance owner THGgLF is 0, count of leases to target is 1 and maxScaleCount 0 
2025-09-16 21:56:30,826       [boundedElastic-3] INFO  com.azure.cosmos.implementation.changefeed.pkversion.PartitionLoadBalancerImpl - Found 1 total leases, taking ownership of 1
2025-09-16 21:56:30,835       [boundedElastic-3] WARN  com.azure.cosmos.implementation.caches.AsyncCacheNonBlocking - cache[LncIALngHpg=] value found without forceRefresh requirement with callIdentifier [358ef817-9d72-4e33-98d7-b98b682ac7fd]
2025-09-16 21:56:30,838       [boundedElastic-3] WARN  com.azure.cosmos.implementation.caches.AsyncCacheNonBlocking - cache[LncIALngHpg=] value found without forceRefresh requirement with callIdentifier [26043510-30f0-4b32-a122-17aaaa4ed617]
2025-09-16 21:56:30,882       [boundedElastic-3] INFO  com.azure.cosmos.implementation.changefeed.pkversion.PartitionControllerImpl - Partition 0: acquired. Owner: THGgLF
2025-09-16 21:56:30,894       [boundedElastic-3] INFO  com.azure.cosmos.implementation.changefeed.common.DefaultObserver - Open processing from thread 63
2025-09-16 21:56:30,895       [boundedElastic-4] INFO  com.azure.cosmos.implementation.changefeed.pkversion.PartitionProcessorImpl - Partition 0: processing task started with owner THGgLF.
2025-09-16 21:56:30,895       [boundedElastic-2] INFO  com.azure.cosmos.implementation.changefeed.pkversion.LeaseRenewerImpl - Partition 0: renewer task started.
2025-09-16 21:56:30,911       [boundedElastic-4] WARN  com.azure.cosmos.implementation.caches.AsyncCacheNonBlocking - cache[LncIAK6T6d8=] doesn't exist, computing new value
2025-09-16 21:56:30,912       [boundedElastic-4] WARN  com.azure.cosmos.implementation.caches.RxPartitionKeyRangeCache - Reading PartitionKeyRanges for collection : [TestFeedContainer] with rid : [LncIAK6T6d8=] by UserAgent : [azsdk-java-cosmos/4.74.0 Windows11/10.0 JRE/21.0.8] by CallPath : [RxPartitionKeyRangeCache.TryLookupAsync:,RxPartitionKeyRangeCache.GetRoutingMapForCollectionAsync:,RxPartitionKeyRangeCache.GetPartitionKeyRange:LncIAK6T6d8=,] by CallIdentifier [b72b510c-86b7-4d86-8b60-8a4cb73770ad] with Prefetch [1]
2025-09-16 21:56:30,912       [boundedElastic-4] WARN  com.azure.cosmos.implementation.RxDocumentClientImpl - ReadFeed call made for ResourceType : [PartitionKeyRange] and ResourceLink : [/dbs/LncIAA==/colls/LncIAK6T6d8=/pkranges/] with pageSize : [100] for UserAgent : [azsdk-java-cosmos/4.74.0 Windows11/10.0 JRE/21.0.8] and CallIdentifier : [b72b510c-86b7-4d86-8b60-8a4cb73770ad]
2025-09-16 21:56:30,921       [transport-response-bounded-elastic-1] WARN  com.azure.cosmos.CosmosException - Resolved retryAfterInMilliseconds : [500] from RetryAfterInMilliseconds header : [500] and MAX_RETRY_AFTER_IN_MS : [5000].
2025-09-16 21:56:30,921       [transport-response-bounded-elastic-1] WARN  com.azure.cosmos.implementation.ResourceThrottleRetryPolicy - Operation will be retried after 500 milliseconds. Current attempt 1, Cumulative delay PT0.5S for statusCode 429 and subStatusCode 3200
2025-09-16 21:56:31,435       [cosmos-parallel-6] WARN  com.azure.cosmos.implementation.RxDocumentClientImpl - ReadFeed call made for ResourceType : [PartitionKeyRange] and ResourceLink : [/dbs/LncIAA==/colls/LncIAK6T6d8=/pkranges/] with pageSize : [100] for UserAgent : [azsdk-java-cosmos/4.74.0 Windows11/10.0 JRE/21.0.8] and CallIdentifier : [b72b510c-86b7-4d86-8b60-8a4cb73770ad]
2025-09-16 21:56:31,437       [transport-response-bounded-elastic-1] WARN  com.azure.cosmos.CosmosException - Resolved retryAfterInMilliseconds : [500] from RetryAfterInMilliseconds header : [500] and MAX_RETRY_AFTER_IN_MS : [5000].
2025-09-16 21:56:31,437       [transport-response-bounded-elastic-1] WARN  com.azure.cosmos.implementation.ResourceThrottleRetryPolicy - Operation will be retried after 500 milliseconds. Current attempt 2, Cumulative delay PT1S for statusCode 429 and subStatusCode 3200
2025-09-16 21:56:31,943       [cosmos-parallel-1] WARN  com.azure.cosmos.implementation.RxDocumentClientImpl - ReadFeed call made for ResourceType : [PartitionKeyRange] and ResourceLink : [/dbs/LncIAA==/colls/LncIAK6T6d8=/pkranges/] with pageSize : [100] for UserAgent : [azsdk-java-cosmos/4.74.0 Windows11/10.0 JRE/21.0.8] and CallIdentifier : [b72b510c-86b7-4d86-8b60-8a4cb73770ad]
2025-09-16 21:56:31,947       [transport-response-bounded-elastic-1] WARN  com.azure.cosmos.CosmosException - Resolved retryAfterInMilliseconds : [500] from RetryAfterInMilliseconds header : [500] and MAX_RETRY_AFTER_IN_MS : [5000].
2025-09-16 21:56:31,947       [transport-response-bounded-elastic-1] WARN  com.azure.cosmos.implementation.ResourceThrottleRetryPolicy - Operation will be retried after 500 milliseconds. Current attempt 3, Cumulative delay PT1.5S for statusCode 429 and subStatusCode 3200
2025-09-16 21:56:32,455       [cosmos-parallel-5] WARN  com.azure.cosmos.implementation.RxDocumentClientImpl - ReadFeed call made for ResourceType : [PartitionKeyRange] and ResourceLink : [/dbs/LncIAA==/colls/LncIAK6T6d8=/pkranges/] with pageSize : [100] for UserAgent : [azsdk-java-cosmos/4.74.0 Windows11/10.0 JRE/21.0.8] and CallIdentifier : [b72b510c-86b7-4d86-8b60-8a4cb73770ad]
2025-09-16 21:56:32,457       [transport-response-bounded-elastic-1] WARN  com.azure.cosmos.CosmosException - Resolved retryAfterInMilliseconds : [500] from RetryAfterInMilliseconds header : [500] and MAX_RETRY_AFTER_IN_MS : [5000].
2025-09-16 21:56:32,457       [transport-response-bounded-elastic-1] WARN  com.azure.cosmos.implementation.ResourceThrottleRetryPolicy - Operation will be retried after 500 milliseconds. Current attempt 4, Cumulative delay PT2S for statusCode 429 and subStatusCode 3200
2025-09-16 21:56:32,969       [cosmos-parallel-9] WARN  com.azure.cosmos.implementation.RxDocumentClientImpl - ReadFeed call made for ResourceType : [PartitionKeyRange] and ResourceLink : [/dbs/LncIAA==/colls/LncIAK6T6d8=/pkranges/] with pageSize : [100] for UserAgent : [azsdk-java-cosmos/4.74.0 Windows11/10.0 JRE/21.0.8] and CallIdentifier : [b72b510c-86b7-4d86-8b60-8a4cb73770ad]
2025-09-16 21:56:32,971       [transport-response-bounded-elastic-1] WARN  com.azure.cosmos.CosmosException - Resolved retryAfterInMilliseconds : [500] from RetryAfterInMilliseconds header : [500] and MAX_RETRY_AFTER_IN_MS : [5000].
2025-09-16 21:56:32,971       [transport-response-bounded-elastic-1] WARN  com.azure.cosmos.implementation.ResourceThrottleRetryPolicy - Operation will be retried after 500 milliseconds. Current attempt 5, Cumulative delay PT2.5S for statusCode 429 and subStatusCode 3200
2025-09-16 21:56:33,481       [cosmos-parallel-6] WARN  com.azure.cosmos.implementation.RxDocumentClientImpl - ReadFeed call made for ResourceType : [PartitionKeyRange] and ResourceLink : [/dbs/LncIAA==/colls/LncIAK6T6d8=/pkranges/] with pageSize : [100] for UserAgent : [azsdk-java-cosmos/4.74.0 Windows11/10.0 JRE/21.0.8] and CallIdentifier : [b72b510c-86b7-4d86-8b60-8a4cb73770ad]
2025-09-16 21:56:33,483       [transport-response-bounded-elastic-1] WARN  com.azure.cosmos.CosmosException - Resolved retryAfterInMilliseconds : [500] from RetryAfterInMilliseconds header : [500] and MAX_RETRY_AFTER_IN_MS : [5000].
2025-09-16 21:56:33,483       [transport-response-bounded-elastic-1] WARN  com.azure.cosmos.implementation.ResourceThrottleRetryPolicy - Operation will be retried after 500 milliseconds. Current attempt 6, Cumulative delay PT3S for statusCode 429 and subStatusCode 3200
2025-09-16 21:56:33,990       [cosmos-parallel-7] WARN  com.azure.cosmos.implementation.RxDocumentClientImpl - ReadFeed call made for ResourceType : [PartitionKeyRange] and ResourceLink : [/dbs/LncIAA==/colls/LncIAK6T6d8=/pkranges/] with pageSize : [100] for UserAgent : [azsdk-java-cosmos/4.74.0 Windows11/10.0 JRE/21.0.8] and CallIdentifier : [b72b510c-86b7-4d86-8b60-8a4cb73770ad]
2025-09-16 21:56:33,991       [transport-response-bounded-elastic-1] WARN  com.azure.cosmos.CosmosException - Resolved retryAfterInMilliseconds : [500] from RetryAfterInMilliseconds header : [500] and MAX_RETRY_AFTER_IN_MS : [5000].
2025-09-16 21:56:33,991       [transport-response-bounded-elastic-1] WARN  com.azure.cosmos.implementation.ResourceThrottleRetryPolicy - Operation will be retried after 500 milliseconds. Current attempt 7, Cumulative delay PT3.5S for statusCode 429 and subStatusCode 3200
2025-09-16 21:56:34,500       [cosmos-parallel-5] WARN  com.azure.cosmos.implementation.RxDocumentClientImpl - ReadFeed call made for ResourceType : [PartitionKeyRange] and ResourceLink : [/dbs/LncIAA==/colls/LncIAK6T6d8=/pkranges/] with pageSize : [100] for UserAgent : [azsdk-java-cosmos/4.74.0 Windows11/10.0 JRE/21.0.8] and CallIdentifier : [b72b510c-86b7-4d86-8b60-8a4cb73770ad]
2025-09-16 21:56:34,501       [transport-response-bounded-elastic-1] WARN  com.azure.cosmos.CosmosException - Resolved retryAfterInMilliseconds : [500] from RetryAfterInMilliseconds header : [500] and MAX_RETRY_AFTER_IN_MS : [5000].
2025-09-16 21:56:34,501       [transport-response-bounded-elastic-1] WARN  com.azure.cosmos.implementation.ResourceThrottleRetryPolicy - Operation will be retried after 500 milliseconds. Current attempt 8, Cumulative delay PT4S for statusCode 429 and subStatusCode 3200
2025-09-16 21:56:34,703       [reactor-http-nio-5] INFO  com.azure.cosmos.implementation.clienttelemetry.ClientTelemetry - Client is not on azure vm
2025-09-16 21:56:34,704       [reactor-http-nio-5] WARN  com.azure.cosmos.implementation.RxDocumentClientImpl - Initialized DocumentClient [2] with machineId[uuid:6a5850d6-35c6-489a-ba6b-9b861ee6d839] serviceEndpoint [https://abhm-cosmosdb-multi-writer-multi-consistency.documents.azure.com:443/], connectionPolicy [ConnectionPolicy{httpNetworkRequestTimeout=PT1M, tcpNetworkRequestTimeout=PT5S, connectionMode=GATEWAY, maxConnectionPoolSize=1000, idleHttpConnectionTimeout=PT1M, idleTcpConnectionTimeout=PT0S, userAgentSuffix='', throttlingRetryOptions=RetryOptions{maxRetryAttemptsOnThrottledRequests=9, maxRetryWaitTime=PT30S}, endpointDiscoveryEnabled=true, preferredRegions=null, multipleWriteRegionsEnabled=false, proxyType=null, inetSocketProxyAddress=null, readRequestsFallbackEnabled=true, connectTimeout=PT5S, idleTcpEndpointTimeout=PT1H, maxConnectionsPerEndpoint=130, maxRequestsPerConnection=30, tcpConnectionEndpointRediscoveryEnabled=true, ioThreadPriority=5, ioThreadCountPerCoreFactor=2, tcpHealthCheckTimeoutDetectionEnabled=true, minConnectionPoolSizePerEndpoint=1, openConnectionsConcurrency=1, aggressiveWarmupConcurrency=8, http2ConnectionConfig=(enabled:false, maxc:1000, minc:8, maxs:30), pendingAcquireMaxCount=DEFAULT}], consistencyLevel [Session], readConsistencyStrategy [null]
2025-09-16 21:56:35,009       [cosmos-parallel-1] WARN  com.azure.cosmos.implementation.RxDocumentClientImpl - ReadFeed call made for ResourceType : [PartitionKeyRange] and ResourceLink : [/dbs/LncIAA==/colls/LncIAK6T6d8=/pkranges/] with pageSize : [100] for UserAgent : [azsdk-java-cosmos/4.74.0 Windows11/10.0 JRE/21.0.8] and CallIdentifier : [b72b510c-86b7-4d86-8b60-8a4cb73770ad]
2025-09-16 21:56:35,011       [transport-response-bounded-elastic-1] WARN  com.azure.cosmos.CosmosException - Resolved retryAfterInMilliseconds : [500] from RetryAfterInMilliseconds header : [500] and MAX_RETRY_AFTER_IN_MS : [5000].
2025-09-16 21:56:35,011       [transport-response-bounded-elastic-1] WARN  com.azure.cosmos.implementation.ResourceThrottleRetryPolicy - Operation will be retried after 500 milliseconds. Current attempt 9, Cumulative delay PT4.5S for statusCode 429 and subStatusCode 3200
2025-09-16 21:56:35,522       [cosmos-parallel-8] WARN  com.azure.cosmos.implementation.RxDocumentClientImpl - ReadFeed call made for ResourceType : [PartitionKeyRange] and ResourceLink : [/dbs/LncIAA==/colls/LncIAK6T6d8=/pkranges/] with pageSize : [100] for UserAgent : [azsdk-java-cosmos/4.74.0 Windows11/10.0 JRE/21.0.8] and CallIdentifier : [b72b510c-86b7-4d86-8b60-8a4cb73770ad]
2025-09-16 21:56:35,525       [transport-response-bounded-elastic-1] WARN  com.azure.cosmos.implementation.ResourceThrottleRetryPolicy - Operation will NOT be retried. Current attempt 9
com.azure.cosmos.implementation.RequestRateTooLargeException: {"innerErrorMessage":null,"cosmosDiagnostics":{"userAgent":"azsdk-java-cosmos/4.74.0 Windows11/10.0 JRE/21.0.8","activityId":"a21f2d69-5be8-47b8-8c6d-c4b27c48956c","requestLatencyInMs":4612,"requestStartTimeUTC":"2025-09-17T01:56:30.912438400Z","requestEndTimeUTC":"2025-09-17T01:56:35.525297900Z","responseStatisticsList":[],"supplementalResponseStatisticsList":[],"addressResolutionStatistics":{},"regionsContacted":["central us"],"retryContext":{"statusAndSubStatusCodes":[[429,3200],[429,3200],[429,3200],[429,3200],[429,3200],[429,3200],[429,3200],[429,3200],[429,3200]],"retryCount":9,"retryLatency":4604},"metadataDiagnosticsContext":{"metadataDiagnosticList":null,"empty":true},"serializationDiagnosticsContext":{"serializationDiagnosticsList":null},"gatewayStatisticsList":[{"sessionToken":null,"operationType":"ReadFeed","resourceType":"PartitionKeyRange","statusCode":429,"subStatusCode":3200,"requestCharge":0.0,"requestTimeline":[{"eventName":"connectionAcquired","startTimeUTC":"2025-09-17T01:56:30.913439100Z","durationInMilliSecs":5.0953},{"eventName":"connectionConfigured","startTimeUTC":null,"durationInMilliSecs":0.0},{"eventName":"requestSent","startTimeUTC":null,"durationInMilliSecs":0.0},{"eventName":"transitTime","startTimeUTC":null,"durationInMilliSecs":0.0},{"eventName":"received","startTimeUTC":null,"durationInMilliSecs":0.0}],"partitionKeyRangeId":null,"responsePayloadSizeInBytes":0,"exceptionResponseHeaders":"{x-ms-retry-after-ms=500, x-ms-cosmos-llsn=0, x-ms-activity-id=4d9caa81-1c11-4402-9316-c4a188df8486, x-ms-substatus=3200}","faultInjectionRuleId":"pkrange-throttled-error-dc84effc-bc71-4e2a-b723-d5f4f16a3773","endpoint":"https://abhm-cosmosdb-multi-writer-multi-consistency-centralus.documents.azure.com:443/dbs/LncIAA==/colls/LncIAK6T6d8=/pkranges"},{"sessionToken":null,"operationType":"ReadFeed","resourceType":"PartitionKeyRange","statusCode":429,"subStatusCode":3200,"requestCharge":0.0,"requestTimeline":[{"eventName":"connectionAcquired","startTimeUTC":"2025-09-17T01:56:31.436500600Z","durationInMilliSecs":0.9524},{"eventName":"connectionConfigured","startTimeUTC":null,"durationInMilliSecs":0.0},{"eventName":"requestSent","startTimeUTC":null,"durationInMilliSecs":0.0},{"eventName":"transitTime","startTimeUTC":null,"durationInMilliSecs":0.0},{"eventName":"received","startTimeUTC":null,"durationInMilliSecs":0.0}],"partitionKeyRangeId":null,"responsePayloadSizeInBytes":0,"exceptionResponseHeaders":"{x-ms-retry-after-ms=500, x-ms-cosmos-llsn=0, x-ms-activity-id=f6db69d7-fb43-4eaa-a631-484103a8d369, x-ms-substatus=3200}","faultInjectionRuleId":"pkrange-throttled-error-dc84effc-bc71-4e2a-b723-d5f4f16a3773","endpoint":"https://abhm-cosmosdb-multi-writer-multi-consistency-centralus.documents.azure.com:443/dbs/LncIAA==/colls/LncIAK6T6d8=/pkranges"},{"sessionToken":null,"operationType":"ReadFeed","resourceType":"PartitionKeyRange","statusCode":429,"subStatusCode":3200,"requestCharge":0.0,"requestTimeline":[{"eventName":"connectionAcquired","startTimeUTC":"2025-09-17T01:56:31.945051500Z","durationInMilliSecs":1.0178},{"eventName":"connectionConfigured","startTimeUTC":null,"durationInMilliSecs":0.0},{"eventName":"requestSent","startTimeUTC":null,"durationInMilliSecs":0.0},{"eventName":"transitTime","startTimeUTC":null,"durationInMilliSecs":0.0},{"eventName":"received","startTimeUTC":null,"durationInMilliSecs":0.0}],"partitionKeyRangeId":null,"responsePayloadSizeInBytes":0,"exceptionResponseHeaders":"{x-ms-retry-after-ms=500, x-ms-cosmos-llsn=0, x-ms-activity-id=7a465514-5d32-4c80-9660-92b3b634fa52, x-ms-substatus=3200}","faultInjectionRuleId":"pkrange-throttled-error-dc84effc-bc71-4e2a-b723-d5f4f16a3773","endpoint":"https://abhm-cosmosdb-multi-writer-multi-consistency-centralus.documents.azure.com:443/dbs/LncIAA==/colls/LncIAK6T6d8=/pkranges"},{"sessionToken":null,"operationType":"ReadFeed","resourceType":"PartitionKeyRange","statusCode":429,"subStatusCode":3200,"requestCharge":0.0,"requestTimeline":[{"eventName":"connectionAcquired","startTimeUTC":"2025-09-17T01:56:32.456418500Z","durationInMilliSecs":1.5091},{"eventName":"connectionConfigured","startTimeUTC":null,"durationInMilliSecs":0.0},{"eventName":"requestSent","startTimeUTC":null,"durationInMilliSecs":0.0},{"eventName":"transitTime","startTimeUTC":null,"durationInMilliSecs":0.0},{"eventName":"received","startTimeUTC":null,"durationInMilliSecs":0.0}],"partitionKeyRangeId":null,"responsePayloadSizeInBytes":0,"exceptionResponseHeaders":"{x-ms-retry-after-ms=500, x-ms-cosmos-llsn=0, x-ms-activity-id=8206ca74-2000-401d-b600-d492f0bbde75, x-ms-substatus=3200}","faultInjectionRuleId":"pkrange-throttled-error-dc84effc-bc71-4e2a-b723-d5f4f16a3773","endpoint":"https://abhm-cosmosdb-multi-writer-multi-consistency-centralus.documents.azure.com:443/dbs/LncIAA==/colls/LncIAK6T6d8=/pkranges"},{"sessionToken":null,"operationType":"ReadFeed","resourceType":"PartitionKeyRange","statusCode":429,"subStatusCode":3200,"requestCharge":0.0,"requestTimeline":[{"eventName":"connectionAcquired","startTimeUTC":"2025-09-17T01:56:32.970152500Z","durationInMilliSecs":0.0},{"eventName":"connectionConfigured","startTimeUTC":null,"durationInMilliSecs":0.0},{"eventName":"requestSent","startTimeUTC":null,"durationInMilliSecs":0.0},{"eventName":"transitTime","startTimeUTC":null,"durationInMilliSecs":0.0},{"eventName":"received","startTimeUTC":null,"durationInMilliSecs":0.0}],"partitionKeyRangeId":null,"responsePayloadSizeInBytes":0,"exceptionResponseHeaders":"{x-ms-retry-after-ms=500, x-ms-cosmos-llsn=0, x-ms-activity-id=b89ebc62-c096-4cff-9560-ad8227cca457, x-ms-substatus=3200}","faultInjectionRuleId":"pkrange-throttled-error-dc84effc-bc71-4e2a-b723-d5f4f16a3773","endpoint":"https://abhm-cosmosdb-multi-writer-multi-consistency-centralus.documents.azure.com:443/dbs/LncIAA==/colls/LncIAK6T6d8=/pkranges"},{"sessionToken":null,"operationType":"ReadFeed","resourceType":"PartitionKeyRange","statusCode":429,"subStatusCode":3200,"requestCharge":0.0,"requestTimeline":[{"eventName":"connectionAcquired","startTimeUTC":"2025-09-17T01:56:33.482592400Z","durationInMilliSecs":0.0},{"eventName":"connectionConfigured","startTimeUTC":null,"durationInMilliSecs":0.0},{"eventName":"requestSent","startTimeUTC":null,"durationInMilliSecs":0.0},{"eventName":"transitTime","startTimeUTC":null,"durationInMilliSecs":0.0},{"eventName":"received","startTimeUTC":null,"durationInMilliSecs":0.0}],"partitionKeyRangeId":null,"responsePayloadSizeInBytes":0,"exceptionResponseHeaders":"{x-ms-retry-after-ms=500, x-ms-cosmos-llsn=0, x-ms-activity-id=01d2d089-88d6-4a4b-aab0-1ae46f8a4ee0, x-ms-substatus=3200}","faultInjectionRuleId":"pkrange-throttled-error-dc84effc-bc71-4e2a-b723-d5f4f16a3773","endpoint":"https://-centralus.documents.azure.com:443/dbs/LncIAA==/colls/LncIAK6T6d8=/pkranges"},{"sessionToken":null,"operationType":"ReadFeed","resourceType":"PartitionKeyRange","statusCode":429,"subStatusCode":3200,"requestCharge":0.0,"requestTimeline":[{"eventName":"connectionAcquired","startTimeUTC":"2025-09-17T01:56:33.991854700Z","durationInMilliSecs":0.0},{"eventName":"connectionConfigured","startTimeUTC":null,"durationInMilliSecs":0.0},{"eventName":"requestSent","startTimeUTC":null,"durationInMilliSecs":0.0},{"eventName":"transitTime","startTimeUTC":null,"durationInMilliSecs":0.0},{"eventName":"received","startTimeUTC":null,"durationInMilliSecs":0.0}],"partitionKeyRangeId":null,"responsePayloadSizeInBytes":0,"exceptionResponseHeaders":"{x-ms-retry-after-ms=500, x-ms-cosmos-llsn=0, x-ms-activity-id=8f731638-5cd1-4973-9701-96d8786dd6b7, x-ms-substatus=3200}","faultInjectionRuleId":"pkrange-throttled-error-dc84effc-bc71-4e2a-b723-d5f4f16a3773","endpoint":"https://abhm-cosmosdb-multi-writer-multi-consistency-centralus.documents.azure.com:443/dbs/LncIAA==/colls/LncIAK6T6d8=/pkranges"},{"sessionToken":null,"operationType":"ReadFeed","resourceType":"PartitionKeyRange","statusCode":429,"subStatusCode":3200,"requestCharge":0.0,"requestTimeline":[{"eventName":"connectionAcquired","startTimeUTC":"2025-09-17T01:56:34.500009Z","durationInMilliSecs":1.0224},{"eventName":"connectionConfigured","startTimeUTC":null,"durationInMilliSecs":0.0},{"eventName":"requestSent","startTimeUTC":null,"durationInMilliSecs":0.0},{"eventName":"transitTime","startTimeUTC":null,"durationInMilliSecs":0.0},{"eventName":"received","startTimeUTC":null,"durationInMilliSecs":0.0}],"partitionKeyRangeId":null,"responsePayloadSizeInBytes":0,"exceptionResponseHeaders":"{x-ms-retry-after-ms=500, x-ms-cosmos-llsn=0, x-ms-activity-id=5bf71006-9a6d-46c4-8050-4d406cc22c15, x-ms-substatus=3200}","faultInjectionRuleId":"pkrange-throttled-error-dc84effc-bc71-4e2a-b723-d5f4f16a3773","endpoint":"https://--centralus.documents.azure.com:443/dbs/LncIAA==/colls/LncIAK6T6d8=/pkranges"},{"sessionToken":null,"operationType":"ReadFeed","resourceType":"PartitionKeyRange","statusCode":429,"subStatusCode":3200,"requestCharge":0.0,"requestTimeline":[{"eventName":"connectionAcquired","startTimeUTC":"2025-09-17T01:56:35.010854800Z","durationInMilliSecs":0.993},{"eventName":"connectionConfigured","startTimeUTC":null,"durationInMilliSecs":0.0},{"eventName":"requestSent","startTimeUTC":null,"durationInMilliSecs":0.0},{"eventName":"transitTime","startTimeUTC":null,"durationInMilliSecs":0.0},{"eventName":"received","startTimeUTC":null,"durationInMilliSecs":0.0}],"partitionKeyRangeId":null,"responsePayloadSizeInBytes":0,"exceptionResponseHeaders":"{x-ms-retry-after-ms=500, x-ms-cosmos-llsn=0, x-ms-activity-id=024dcd74-7afa-427c-acee-3bc143c3720f, x-ms-substatus=3200}","faultInjectionRuleId":"pkrange-throttled-error-dc84effc-bc71-4e2a-b723-d5f4f16a3773","endpoint":"https://abhm-cosmosdb-multi-writer-multi-consistency-centralus.documents.azure.com:443/dbs/LncIAA==/colls/LncIAK6T6d8=/pkranges"},{"sessionToken":null,"operationType":"ReadFeed","resourceType":"PartitionKeyRange","statusCode":429,"subStatusCode":3200,"requestCharge":0.0,"requestTimeline":[{"eventName":"connectionAcquired","startTimeUTC":"2025-09-17T01:56:35.523669200Z","durationInMilliSecs":1.6287},{"eventName":"connectionConfigured","startTimeUTC":null,"durationInMilliSecs":0.0},{"eventName":"requestSent","startTimeUTC":null,"durationInMilliSecs":0.0},{"eventName":"transitTime","startTimeUTC":null,"durationInMilliSecs":0.0},{"eventName":"received","startTimeUTC":null,"durationInMilliSecs":0.0}],"partitionKeyRangeId":null,"responsePayloadSizeInBytes":0,"exceptionResponseHeaders":"{x-ms-retry-after-ms=500, x-ms-cosmos-llsn=0, x-ms-activity-id=a21f2d69-5be8-47b8-8c6d-c4b27c48956c, x-ms-substatus=3200}","faultInjectionRuleId":"pkrange-throttled-error-dc84effc-bc71-4e2a-b723-d5f4f16a3773","endpoint":"https://-centralus.documents.azure.com:443/dbs/LncIAA==/colls/LncIAK6T6d8=/pkranges"}],"samplingRateSnapshot":1.0,"bloomFilterInsertionCountSnapshot":0,"systemInformation":{"usedMemory":"29498 KB","availableMemory":"4164806 KB","systemCpuLoad":"(2025-09-17T01:56:24.784272400Z 11.8%), (2025-09-17T01:56:29.484877400Z 16.2%), (2025-09-17T01:56:34.499159400Z 20.3%)","availableProcessors":8},"clientCfgs":{"id":2,"machineId":"uuid:6a5850d6-35c6-489a-ba6b-9b861ee6d839","connectionMode":"GATEWAY","numberOfClients":1,"isPpafEnabled":"","isFalseProgSessionTokenMergeEnabled":"true","excrgns":"[]","clientEndpoints":{"https://abhm-cosmosdb-multi-writer-multi-consistency.documents.azure.com:443/":2},"connCfg":{"rntbd":null,"gw":"(cps:1000, nrto:PT1M, icto:PT1M, cto:PT45S, p:false, http2:(enabled:false, maxc:1000, minc:8, maxs:30))","other":"(ed: true, cs: false, rv: true)"},"consistencyCfg":"(consistency: Session, readConsistencyStrategy: null,  mm: false, prgns: [])","proactiveInitCfg":"","e2ePolicyCfg":"","sessionRetryCfg":"","partitionLevelCircuitBreakerCfg":"(cb: false, type: CONSECUTIVE_EXCEPTION_COUNT_BASED, rexcntt: 10, wexcntt: 5)"}}}
	at com.azure.cosmos.test.implementation.faultinjection.FaultInjectionServerErrorResultInternal.getInjectedServerError(FaultInjectionServerErrorResultInternal.java:105) ~[classes/:?]
	at com.azure.cosmos.test.implementation.faultinjection.FaultInjectionServerErrorRule.getInjectedServerError(FaultInjectionServerErrorRule.java:141) ~[classes/:?]
	at com.azure.cosmos.test.implementation.faultinjection.ServerErrorInjector.injectServerResponseError(ServerErrorInjector.java:96) ~[classes/:?]
	at com.azure.cosmos.implementation.faultinjection.GatewayServerErrorInjector.injectGatewayServerResponseError(GatewayServerErrorInjector.java:218) ~[classes/:?]
	at com.azure.cosmos.implementation.faultinjection.GatewayServerErrorInjector.lambda$injectGatewayErrors$3(GatewayServerErrorInjector.java:150) ~[classes/:?]
	at reactor.core.publisher.FluxFlatMap.trySubscribeScalarMap(FluxFlatMap.java:153) ~[reactor-core-3.7.8.jar:3.7.8]
	at reactor.core.publisher.MonoFlatMap.subscribeOrReturn(MonoFlatMap.java:53) ~[reactor-core-3.7.8.jar:3.7.8]
	at reactor.core.publisher.Mono.subscribe(Mono.java:4560) ~[reactor-core-3.7.8.jar:3.7.8]
	at reactor.core.publisher.FluxFlatMap.trySubscribeScalarMap(FluxFlatMap.java:202) ~[reactor-core-3.7.8.jar:3.7.8]
	at reactor.core.publisher.MonoFlatMap.subscribeOrReturn(MonoFlatMap.java:53) ~[reactor-core-3.7.8.jar:3.7.8]
	at reactor.core.publisher.InternalMonoOperator.subscribe(InternalMonoOperator.java:63) ~[reactor-core-3.7.8.jar:3.7.8]
	at reactor.core.publisher.MonoDefer.subscribe(MonoDefer.java:53) ~[reactor-core-3.7.8.jar:3.7.8]
	at reactor.core.publisher.FluxRetryWhen.subscribe(FluxRetryWhen.java:81) ~[reactor-core-3.7.8.jar:3.7.8]
	at reactor.core.publisher.MonoRetryWhen.subscribeOrReturn(MonoRetryWhen.java:46) ~[reactor-core-3.7.8.jar:3.7.8]
	at reactor.core.publisher.InternalMonoOperator.subscribe(InternalMonoOperator.java:63) ~[reactor-core-3.7.8.jar:3.7.8]
	at reactor.core.publisher.MonoIgnoreThen$ThenIgnoreMain.subscribeNext(MonoIgnoreThen.java:241) ~[reactor-core-3.7.8.jar:3.7.8]
	at reactor.core.publisher.MonoIgnoreThen.subscribe(MonoIgnoreThen.java:51) ~[reactor-core-3.7.8.jar:3.7.8]
	at reactor.core.publisher.Mono.subscribe(Mono.java:4576) ~[reactor-core-3.7.8.jar:3.7.8]
	at reactor.core.publisher.FluxFlatMap.trySubscribeScalarMap(FluxFlatMap.java:202) ~[reactor-core-3.7.8.jar:3.7.8]
	at reactor.core.publisher.MonoFlatMap.subscribeOrReturn(MonoFlatMap.java:53) ~[reactor-core-3.7.8.jar:3.7.8]
	at reactor.core.publisher.Flux.subscribe(Flux.java:8876) ~[reactor-core-3.7.8.jar:3.7.8]
	at reactor.core.publisher.FluxMergeSequential$MergeSequentialMain.onNext(FluxMergeSequential.java:237) ~[reactor-core-3.7.8.jar:3.7.8]
	at reactor.core.publisher.FluxGenerate$GenerateSubscription.next(FluxGenerate.java:178) ~[reactor-core-3.7.8.jar:3.7.8]
	at com.azure.cosmos.implementation.query.Paginator.lambda$getPaginatedQueryResultAsObservable$1(Paginator.java:136) ~[classes/:?]
	at reactor.core.publisher.FluxGenerate$GenerateSubscription.slowPath(FluxGenerate.java:271) ~[reactor-core-3.7.8.jar:3.7.8]
	at reactor.core.publisher.FluxGenerate$GenerateSubscription.request(FluxGenerate.java:213) ~[reactor-core-3.7.8.jar:3.7.8]
	at reactor.core.publisher.FluxMergeSequential$MergeSequentialMain.onSubscribe(FluxMergeSequential.java:198) ~[reactor-core-3.7.8.jar:3.7.8]
	at reactor.core.publisher.FluxGenerate.subscribe(FluxGenerate.java:85) ~[reactor-core-3.7.8.jar:3.7.8]
	at reactor.core.publisher.InternalFluxOperator.subscribe(InternalFluxOperator.java:68) ~[reactor-core-3.7.8.jar:3.7.8]
	at reactor.core.publisher.FluxDefer.subscribe(FluxDefer.java:54) ~[reactor-core-3.7.8.jar:3.7.8]
	at reactor.core.publisher.FluxDefer.subscribe(FluxDefer.java:54) ~[reactor-core-3.7.8.jar:3.7.8]
	at reactor.core.publisher.FluxRetryWhen$RetryWhenMainSubscriber.resubscribe(FluxRetryWhen.java:220) ~[reactor-core-3.7.8.jar:3.7.8]
	at reactor.core.publisher.FluxRetryWhen$RetryWhenOtherSubscriber.onNext(FluxRetryWhen.java:274) ~[reactor-core-3.7.8.jar:3.7.8]
	at reactor.core.publisher.FluxFlatMap$FlatMapMain.tryEmit(FluxFlatMap.java:547) ~[reactor-core-3.7.8.jar:3.7.8]
	at reactor.core.publisher.FluxFlatMap$FlatMapInner.onNext(FluxFlatMap.java:988) ~[reactor-core-3.7.8.jar:3.7.8]
	at reactor.core.publisher.FluxFlatMap$FlatMapMain.tryEmit(FluxFlatMap.java:547) ~[reactor-core-3.7.8.jar:3.7.8]
	at reactor.core.publisher.FluxFlatMap$FlatMapInner.onNext(FluxFlatMap.java:988) ~[reactor-core-3.7.8.jar:3.7.8]
	at reactor.core.publisher.MonoDelay$MonoDelayRunnable.propagateDelay(MonoDelay.java:270) ~[reactor-core-3.7.8.jar:3.7.8]
	at reactor.core.publisher.MonoDelay$MonoDelayRunnable.run(MonoDelay.java:285) ~[reactor-core-3.7.8.jar:3.7.8]
	at reactor.core.scheduler.SchedulerTask.call(SchedulerTask.java:68) ~[reactor-core-3.7.8.jar:3.7.8]
	at reactor.core.scheduler.SchedulerTask.call(SchedulerTask.java:28) ~[reactor-core-3.7.8.jar:3.7.8]
	at java.util.concurrent.FutureTask.run$$$capture(FutureTask.java:317) ~[?:?]
	at java.util.concurrent.FutureTask.run(FutureTask.java) ~[?:?]
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642) ~[?:?]
	at java.lang.Thread.run(Thread.java:1583) ~[?:?]
2025-09-16 21:56:35,573       [transport-response-bounded-elastic-1] WARN  com.azure.cosmos.implementation.caches.AsyncCacheNonBlocking - result.getValueAsync [key does not exist] error for cache[LncIAK6T6d8=] resulted in error with statusCode : [429] and subsStatusCode : [3200] and callIdentifier : [b72b510c-86b7-4d86-8b60-8a4cb73770ad]
2025-09-16 21:56:35,573       [transport-response-bounded-elastic-1] WARN  com.azure.cosmos.CosmosException - Resolved retryAfterInMilliseconds : [500] from RetryAfterInMilliseconds header : [500] and MAX_RETRY_AFTER_IN_MS : [5000].
2025-09-16 21:56:35,573       [transport-response-bounded-elastic-1] WARN  com.azure.cosmos.implementation.ResourceThrottleRetryPolicy - Operation will be retried after 500 milliseconds. Current attempt 1, Cumulative delay PT0.5S for statusCode 429 and subStatusCode 3200
2025-09-16 21:56:36,080       [cosmos-parallel-5] WARN  com.azure.cosmos.implementation.caches.AsyncCacheNonBlocking - cache[LncIAK6T6d8=] doesn't exist, computing new value
2025-09-16 21:56:36,081       [cosmos-parallel-5] WARN  com.azure.cosmos.implementation.caches.RxPartitionKeyRangeCache - Reading PartitionKeyRanges for collection : [TestFeedContainer] with rid : [LncIAK6T6d8=] by UserAgent : [azsdk-java-cosmos/4.74.0 Windows11/10.0 JRE/21.0.8] by CallPath : [RxPartitionKeyRangeCache.TryLookupAsync:,RxPartitionKeyRangeCache.GetRoutingMapForCollectionAsync:,RxPartitionKeyRangeCache.GetPartitionKeyRange:LncIAK6T6d8=,] by CallIdentifier [898b6883-bd46-4867-a136-4367d6b1849e] with Prefetch [1]
2025-09-16 21:56:36,081       [cosmos-parallel-5] WARN  com.azure.cosmos.implementation.RxDocumentClientImpl - ReadFeed call made for ResourceType : [PartitionKeyRange] and ResourceLink : [/dbs/LncIAA==/colls/LncIAK6T6d8=/pkranges/] with pageSize : [100] for UserAgent : [azsdk-java-cosmos/4.74.0 Windows11/10.0 JRE/21.0.8] and CallIdentifier : [898b6883-bd46-4867-a136-4367d6b1849e]
2025-09-16 21:56:36,082       [transport-response-bounded-elastic-1] WARN  com.azure.cosmos.CosmosException - Resolved retryAfterInMilliseconds : [500] from RetryAfterInMilliseconds header : [500] and MAX_RETRY_AFTER_IN_MS : [5000].
2025-09-16 21:56:36,082       [transport-response-bounded-elastic-1] WARN  com.azure.cosmos.implementation.ResourceThrottleRetryPolicy - Operation will be retried after 500 milliseconds. Current attempt 1, Cumulative delay PT0.5S for statusCode 429 and subStatusCode 3200
2025-09-16 21:56:36,595       [cosmos-parallel-8] WARN  com.azure.cosmos.implementation.RxDocumentClientImpl - ReadFeed call made for ResourceType : [PartitionKeyRange] and ResourceLink : [/dbs/LncIAA==/colls/LncIAK6T6d8=/pkranges/] with pageSize : [100] for UserAgent : [azsdk-java-cosmos/4.74.0 Windows11/10.0 JRE/21.0.8] and CallIdentifier : [898b6883-bd46-4867-a136-4367d6b1849e]
2025-09-16 21:56:36,596       [transport-response-bounded-elastic-1] WARN  com.azure.cosmos.CosmosException - Resolved retryAfterInMilliseconds : [500] from RetryAfterInMilliseconds header : [500] and MAX_RETRY_AFTER_IN_MS : [5000].
2025-09-16 21:56:36,596       [transport-response-bounded-elastic-1] WARN  com.azure.cosmos.implementation.ResourceThrottleRetryPolicy - Operation will be retried after 500 milliseconds. Current attempt 2, Cumulative delay PT1S for statusCode 429 and subStatusCode 3200
2025-09-16 21:56:37,104       [cosmos-parallel-4] WARN  com.azure.cosmos.implementation.RxDocumentClientImpl - ReadFeed call made for ResourceType : [PartitionKeyRange] and ResourceLink : [/dbs/LncIAA==/colls/LncIAK6T6d8=/pkranges/] with pageSize : [100] for UserAgent : [azsdk-java-cosmos/4.74.0 Windows11/10.0 JRE/21.0.8] and CallIdentifier : [898b6883-bd46-4867-a136-4367d6b1849e]
2025-09-16 21:56:37,106       [transport-response-bounded-elastic-1] WARN  com.azure.cosmos.CosmosException - Resolved retryAfterInMilliseconds : [500] from RetryAfterInMilliseconds header : [500] and MAX_RETRY_AFTER_IN_MS : [5000].
2025-09-16 21:56:37,106       [transport-response-bounded-elastic-1] WARN  com.azure.cosmos.implementation.ResourceThrottleRetryPolicy - Operation will be retried after 500 milliseconds. Current attempt 3, Cumulative delay PT1.5S for statusCode 429 and subStatusCode 3200

```