### PR TITLE
chore(benchmark): wire excludedRegionsList into Cosmos*RequestOptions

### DIFF
--- a/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/AsyncBenchmark.java
+++ b/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/AsyncBenchmark.java
@@ -210,6 +210,7 @@ abstract class AsyncBenchmark<T> implements Benchmark {
                 });
 
             CosmosBulkExecutionOptions bulkExecutionOptions = new CosmosBulkExecutionOptions();
+            bulkExecutionOptions.setExcludedRegions(cfg.getExcludedRegionsList());
             List<CosmosBulkOperationResponse<Object>> failedResponses = Collections.synchronizedList(new ArrayList<>());
             cosmosAsyncContainer
                 .executeBulkOperations(bulkOperationFlux, bulkExecutionOptions)

--- a/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/AsyncQueryBenchmark.java
+++ b/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/AsyncQueryBenchmark.java
@@ -40,6 +40,7 @@ class AsyncQueryBenchmark extends AsyncBenchmark<FeedResponse<PojoizedJson>> {
         Flux<FeedResponse<PojoizedJson>> obs;
         Random r = new Random();
         CosmosQueryRequestOptions options = new CosmosQueryRequestOptions();
+        options.setExcludedRegions(workloadConfig.getExcludedRegionsList());
 
         if (workloadConfig.getOperationType() == Operation.QueryCross) {
 

--- a/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/AsyncQuerySinglePartitionMultiple.java
+++ b/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/AsyncQuerySinglePartitionMultiple.java
@@ -19,6 +19,7 @@ class AsyncQuerySinglePartitionMultiple extends AsyncBenchmark<FeedResponse<Pojo
         super(cfg);
         options = new CosmosQueryRequestOptions();
         options.setPartitionKey(new PartitionKey("pk"));
+        options.setExcludedRegions(cfg.getExcludedRegionsList());
     }
 
     @Override

--- a/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/AsyncReadBenchmark.java
+++ b/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/AsyncReadBenchmark.java
@@ -3,6 +3,7 @@
 
 package com.azure.cosmos.benchmark;
 
+import com.azure.cosmos.models.CosmosItemRequestOptions;
 import com.azure.cosmos.models.CosmosItemResponse;
 import com.azure.cosmos.models.PartitionKey;
 
@@ -18,8 +19,10 @@ class AsyncReadBenchmark extends AsyncBenchmark<PojoizedJson> {
     protected Mono<PojoizedJson> performWorkload(long i) {
         int index = (int) (i % docsToRead.size());
         PojoizedJson doc = docsToRead.get(index);
+        CosmosItemRequestOptions options = new CosmosItemRequestOptions();
+        options.setExcludedRegions(workloadConfig.getExcludedRegionsList());
         return cosmosAsyncContainer.readItem(doc.getId(),
-            new PartitionKey(doc.getId()), PojoizedJson.class)
+            new PartitionKey(doc.getId()), options, PojoizedJson.class)
             .map(CosmosItemResponse::getItem);
     }
 }

--- a/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/AsyncReadManyBenchmark.java
+++ b/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/AsyncReadManyBenchmark.java
@@ -4,6 +4,7 @@
 package com.azure.cosmos.benchmark;
 
 import com.azure.cosmos.models.CosmosItemIdentity;
+import com.azure.cosmos.models.CosmosReadManyRequestOptions;
 import com.azure.cosmos.models.FeedResponse;
 import com.azure.cosmos.models.PartitionKey;
 
@@ -37,6 +38,8 @@ class AsyncReadManyBenchmark extends AsyncBenchmark<FeedResponse<PojoizedJson>> 
             cosmosItemIdentities.add(new CosmosItemIdentity(partitionKey, doc.getId()));
         }
 
-        return cosmosAsyncContainer.readMany(cosmosItemIdentities, PojoizedJson.class);
+        CosmosReadManyRequestOptions options = new CosmosReadManyRequestOptions();
+        options.setExcludedRegions(workloadConfig.getExcludedRegionsList());
+        return cosmosAsyncContainer.readMany(cosmosItemIdentities, options, PojoizedJson.class);
     }
 }

--- a/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/AsyncWriteBenchmark.java
+++ b/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/AsyncWriteBenchmark.java
@@ -3,6 +3,7 @@
 
 package com.azure.cosmos.benchmark;
 
+import com.azure.cosmos.models.CosmosItemRequestOptions;
 import com.azure.cosmos.models.CosmosItemResponse;
 import com.azure.cosmos.models.PartitionKey;
 
@@ -28,18 +29,21 @@ class AsyncWriteBenchmark extends AsyncBenchmark<CosmosItemResponse> {
     protected Mono<CosmosItemResponse> performWorkload(long i) {
         String id = uuid + i;
         Mono<? extends CosmosItemResponse<?>> result;
+        CosmosItemRequestOptions options = new CosmosItemRequestOptions();
+        options.setExcludedRegions(workloadConfig.getExcludedRegionsList());
         if (workloadConfig.isDisablePassingPartitionKeyAsOptionOnWrite()) {
             result = cosmosAsyncContainer.createItem(BenchmarkHelper.generateDocument(id,
                 dataFieldValue,
                 partitionKey,
-                workloadConfig.getDocumentDataFieldCount()));
+                workloadConfig.getDocumentDataFieldCount()),
+                options);
         } else {
             result = cosmosAsyncContainer.createItem(BenchmarkHelper.generateDocument(id,
                 dataFieldValue,
                 partitionKey,
                 workloadConfig.getDocumentDataFieldCount()),
                 new PartitionKey(id),
-                null);
+                options);
         }
         // Raw type cast is required because CosmosItemResponse uses wildcard generics
         // that cannot be expressed in the class type parameter without propagating

--- a/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/SyncBenchmark.java
+++ b/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/SyncBenchmark.java
@@ -186,6 +186,7 @@ abstract class SyncBenchmark<T> implements Benchmark {
                     });
 
                 CosmosBulkExecutionOptions bulkExecutionOptions = new CosmosBulkExecutionOptions();
+                bulkExecutionOptions.setExcludedRegions(workloadCfg.getExcludedRegionsList());
                 List<CosmosBulkOperationResponse<Object>> failedResponses = Collections.synchronizedList(new ArrayList<>());
                 asyncContainer
                     .executeBulkOperations(bulkOperationFlux, bulkExecutionOptions)

--- a/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/SyncReadBenchmark.java
+++ b/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/SyncReadBenchmark.java
@@ -21,7 +21,9 @@ class SyncReadBenchmark extends SyncBenchmark<CosmosItemResponse> {
         PojoizedJson doc = docsToRead.get(index);
 
         String partitionKeyValue = doc.getId();
+        CosmosItemRequestOptions options = new CosmosItemRequestOptions();
+        options.setExcludedRegions(workloadConfig.getExcludedRegionsList());
         return cosmosContainer.readItem(doc.getId(), new PartitionKey(partitionKeyValue),
-                                        new CosmosItemRequestOptions(), InternalObjectNode.class);
+                                        options, InternalObjectNode.class);
     }
 }

--- a/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/SyncWriteBenchmark.java
+++ b/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/SyncWriteBenchmark.java
@@ -3,6 +3,7 @@
 
 package com.azure.cosmos.benchmark;
 
+import com.azure.cosmos.models.CosmosItemRequestOptions;
 import com.azure.cosmos.models.CosmosItemResponse;
 import com.azure.cosmos.models.PartitionKey;
 import org.apache.commons.lang3.RandomStringUtils;
@@ -26,13 +27,15 @@ class SyncWriteBenchmark extends SyncBenchmark<CosmosItemResponse> {
     @Override
     protected CosmosItemResponse performWorkload(long i) throws Exception {
         String id = uuid + i;
-        CosmosItemResponse<PojoizedJson> response;
+        CosmosItemRequestOptions options = new CosmosItemRequestOptions();
+        options.setExcludedRegions(workloadConfig.getExcludedRegionsList());
         if (workloadConfig.isDisablePassingPartitionKeyAsOptionOnWrite()) {
             // require parsing partition key from the doc
             return cosmosContainer.createItem(BenchmarkHelper.generateDocument(id,
                 dataFieldValue,
                 partitionKey,
-                workloadConfig.getDocumentDataFieldCount()));
+                workloadConfig.getDocumentDataFieldCount()),
+                options);
         }
 
         // more optimized for write as partition key is already passed as config
@@ -41,6 +44,6 @@ class SyncWriteBenchmark extends SyncBenchmark<CosmosItemResponse> {
             partitionKey,
             workloadConfig.getDocumentDataFieldCount()),
             new PartitionKey(id),
-            null);
+            options);
     }
 }

--- a/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/TenantDefaultConfig.java
+++ b/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/TenantDefaultConfig.java
@@ -140,6 +140,9 @@ class TenantDefaultConfig {
     @JsonProperty("preferredRegionsList")
     protected String preferredRegionsList;
 
+    @JsonProperty("excludedRegionsList")
+    protected String excludedRegionsList;
+
     @JsonProperty("manageDatabase")
     protected Boolean manageDatabase;
 
@@ -233,6 +236,13 @@ class TenantDefaultConfig {
         return regions;
     }
 
+    public List<String> getExcludedRegionsList() {
+        if (excludedRegionsList == null || excludedRegionsList.isEmpty()) return null;
+        List<String> regions = new ArrayList<>();
+        for (String r : excludedRegionsList.split(",")) { regions.add(r.trim()); }
+        return regions;
+    }
+
     public boolean shouldManageDatabase() { return manageDatabase != null ? manageDatabase : false; }
     public String getApplicationName() { return applicationName != null ? applicationName : ""; }
     public boolean isManagedIdentityRequired() { return isManagedIdentityRequired != null && isManagedIdentityRequired; }
@@ -278,6 +288,7 @@ class TenantDefaultConfig {
         if (http2Enabled != null && tenant.http2Enabled == null) tenant.http2Enabled = http2Enabled;
         if (http2MaxConcurrentStreams != null && tenant.http2MaxConcurrentStreams == null) tenant.http2MaxConcurrentStreams = http2MaxConcurrentStreams;
         if (preferredRegionsList != null && tenant.preferredRegionsList == null) tenant.preferredRegionsList = preferredRegionsList;
+        if (excludedRegionsList != null && tenant.excludedRegionsList == null) tenant.excludedRegionsList = excludedRegionsList;
         if (manageDatabase != null && tenant.manageDatabase == null) tenant.manageDatabase = manageDatabase;
         if (isManagedIdentityRequired != null && tenant.isManagedIdentityRequired == null) tenant.isManagedIdentityRequired = isManagedIdentityRequired;
         if (applicationName != null && tenant.applicationName == null) tenant.applicationName = applicationName;


### PR DESCRIPTION
## Summary
Plumbs the existing `excludedRegionsList` benchmark config field through every per-request `Cosmos*RequestOptions` construction site in the vanilla async/sync workloads of `azure-cosmos-benchmark`. Without this, configuring `excludedRegionsList` had no effect on the actual request paths.

Excluded regions are exposed by the public SDK only at the per-request level (not on `CosmosClientBuilder`), so this change is purely at the request-options layer.

## Changes
**`TenantDefaultConfig.java`** — mirrors `preferredRegionsList`:
- New `excludedRegionsList` field with `@JsonProperty`
- New `getExcludedRegionsList()` that splits the comma-separated value (returns `null` when empty)
- Inheritance line in `applyTo(TenantWorkloadConfig)`

**Wired `setExcludedRegions(workloadConfig.getExcludedRegionsList())` into:**
- `AsyncBenchmark` — `CosmosBulkExecutionOptions` (pre-population bulk path)
- `AsyncQueryBenchmark` — `CosmosQueryRequestOptions`
- `AsyncQuerySinglePartitionMultiple` — `CosmosQueryRequestOptions` in constructor
- `AsyncReadBenchmark` — switched to the `readItem` overload accepting `CosmosItemRequestOptions`
- `AsyncReadManyBenchmark` — switched to the `readMany` overload accepting `CosmosReadManyRequestOptions`
- `AsyncWriteBenchmark` — `CosmosItemRequestOptions` on both `createItem` branches
- `SyncBenchmark` — `CosmosBulkExecutionOptions` (pre-population bulk path)
- `SyncReadBenchmark` — hoisted inline `CosmosItemRequestOptions` to a local
- `SyncWriteBenchmark` — `CosmosItemRequestOptions` on both `createItem` branches

## Out of scope (intentionally not modified)
- `AsyncMixedBenchmark`, `ctl/AsyncCtlWorkload`, `ReadMyWriteWorkflow`, all `encryption/*` workloads — deferred.
- `DocDBUtils`, `BenchmarkHelper` retry path, `CosmosMetricsReporter` — not workload paths (management metadata, retry helper, reporter infra).

## Verification
- `mvn -f sdk/cosmos/azure-cosmos-benchmark/pom.xml -DskipTests -am compile` — passes
- `mvn -f sdk/cosmos/azure-cosmos-benchmark/pom.xml checkstyle:check spotbugs:check` — passes
- Grep audit of `new Cosmos*RequestOptions` / `new CosmosBulkExecutionOptions` in `src/main` confirms every remaining occurrence is either followed by `setExcludedRegions(...)` or is in the intentionally-skipped list above.

10 files changed, +38/-8.